### PR TITLE
docs: move module and function docs to GeoMeasure module

### DIFF
--- a/lib/geomeasure.ex
+++ b/lib/geomeasure.ex
@@ -1,6 +1,82 @@
 defmodule GeoMeasure do
   @moduledoc """
   Calculates properties of Geo structs.
+
+  ## area
+
+  Calculates the area of Geo struct.
+
+  #### Examples:
+
+      iex> GeoMeasure.area(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+      4.0
+
+  ## bbox
+
+  Calculates the bounding box of a Geo struct.
+
+  #### Examples:
+
+      iex> GeoMeasure.bbox(%Geo.Point{coordinates: {1, 2}})
+      %Geo.Point{coordinates: {1, 2}}
+
+      iex> GeoMeasure.bbox(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
+      %Geo.Polygon{coordinates: [[{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}]]}
+
+      iex> GeoMeasure.bbox(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+      %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
+
+  ## centroid
+
+  Calculates the centroid of a Geo struct.
+
+  #### Examples:
+
+      iex> GeoMeasure.centroid(%Geo.Point{coordinates: {1, 2}})
+      %Geo.Point{coordinates: {1, 2}}
+
+      iex> GeoMeasure.centroid(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
+      %Geo.Point{coordinates: {2.0, 3.0}}
+
+      iex> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+      %Geo.Point{coordinates: {1.0, 1.0}}
+
+  ## distance
+
+  Calculates distance between two coordinate pairs or Geo.Point structs.
+
+  #### Examples:
+
+      iex> GeoMeasure.distance({0, 0}, {5, 0})
+      5.0
+
+      iex> GeoMeasure.distance({0, 0}, {3, 4})
+      5.0
+
+      iex> GeoMeasure.distance(%Geo.Point{coordinates: {0, 0}}, %Geo.Point{coordinates: {3, 4}})
+      5.0
+
+  ## extent
+
+  Calculates the extent of a Geo struct.
+
+  #### Examples:
+
+      iex> GeoMeasure.extent(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
+      {1, 3, 2, 4}
+
+      iex> GeoMeasure.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+      {0, 2, 0, 2}
+
+  ## perimeter
+
+  Calculates the perimeter of a Geo struct.
+
+  #### Examples:
+
+      iex> GeoMeasure.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+      8.0
+
   """
 
   alias Geo
@@ -14,22 +90,46 @@ defmodule GeoMeasure do
     Perimeter
   }
 
-  @spec area(Geo.geometry()) :: number() | nil
+  @doc """
+  Calculates the area of a Geo struct.
+  """
+  @doc since: "0.0.1"
+  @spec area(Geo.geometry()) :: number()
   defdelegate area(geometry), to: Area
 
+  @doc """
+  Calculates the bounding box of a Geo struct as a Geo.Polygon.
+  """
+  @doc since: "0.0.1"
   @spec bbox(Geo.geometry()) :: Geo.geometry()
   defdelegate bbox(geometry), to: Bbox
 
+  @doc """
+  Calculates the centroid of a Geo struct as a Geo.Point.
+  """
+  @doc since: "0.0.1"
   @spec centroid(Geo.geometry()) :: Geo.Point.t()
   defdelegate centroid(geometry), to: Centroid
 
+  @doc """
+  Calculates the distance between two coordinate pairs or Geo.Point structs.
+  """
+  @doc since: "0.0.1"
   @spec distance({number(), number()}, {number(), number()}) :: float()
   @spec distance(Geo.Point.t(), Geo.Point.t()) :: float()
   defdelegate distance(coordinates_1, coordinates_2), to: Distance
 
-  @spec extent(Geo.geometry()) :: {number(), number(), number(), number()} | nil
+  @doc """
+  Calculates the extent coordinates of a Geo struct.
+  """
+  @doc since: "0.0.1"
+  @spec extent(Geo.geometry()) :: {number(), number(), number(), number()}
   defdelegate extent(geometry), to: Extent
 
-  @spec perimeter(Geo.geometry()) :: float() | nil
+  @doc """
+  Calculates the perimeter of a Geo struct.
+  """
+  @doc since: "0.0.1"
+  @spec perimeter(Geo.geometry()) :: float()
   defdelegate perimeter(geometry), to: Perimeter
 end

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -1,13 +1,5 @@
 defmodule GeoMeasure.Area do
-  @moduledoc """
-  Calculates the area of Geo struct.
-
-  ## Examples:
-
-      iex> GeoMeasure.Area.area(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
-      4.0
-
-  """
+  @moduledoc false
 
   @spec calculate_area([{number(), number()}]) :: float()
   defp calculate_area(coords) when is_list(coords) do
@@ -32,7 +24,6 @@ defmodule GeoMeasure.Area do
   Calculates the area of a Geo struct.
   """
   @doc since: "0.0.1"
-
   @spec area(Geo.Polygon.t()) :: float()
   def area(%Geo.Polygon{coordinates: [coords]}) do
     calculate_area(coords)

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -1,19 +1,5 @@
 defmodule GeoMeasure.Bbox do
-  @moduledoc """
-  Calculates the bounding box of a Geo struct.
-
-  Examples:
-
-      iex> GeoMeasure.Bbox.bbox(%Geo.Point{coordinates: {1, 2}})
-      %Geo.Point{coordinates: {1, 2}}
-
-      iex> GeoMeasure.Bbox.bbox(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
-      %Geo.Polygon{coordinates: [[{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}]]}
-
-      iex> GeoMeasure.Bbox.bbox(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
-      %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
-
-  """
+  @moduledoc false
 
   alias GeoMeasure.Extent
 

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -1,19 +1,5 @@
 defmodule GeoMeasure.Centroid do
-  @moduledoc """
-  Calculates the centroid of a Geo struct.
-
-  ## Examples:
-
-      iex> GeoMeasure.Centroid.centroid(%Geo.Point{coordinates: {1, 2}})
-      %Geo.Point{coordinates: {1, 2}}
-
-      iex> GeoMeasure.Centroid.centroid(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
-      %Geo.Point{coordinates: {2.0, 3.0}}
-
-      iex> GeoMeasure.Centroid.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
-      %Geo.Point{coordinates: {1.0, 1.0}}
-
-  """
+  @moduledoc false
 
   alias Geo
 

--- a/lib/geomeasure/distance.ex
+++ b/lib/geomeasure/distance.ex
@@ -1,19 +1,5 @@
 defmodule GeoMeasure.Distance do
-  @moduledoc """
-  Calculates distance between two coordinate pairs or Geo.Point structs.
-
-  ## Examples:
-
-      iex> GeoMeasure.Distance.distance({0, 0}, {5, 0})
-      5.0
-
-      iex> GeoMeasure.Distance.distance({0, 0}, {3, 4})
-      5.0
-
-      iex> GeoMeasure.Distance.distance(%Geo.Point{coordinates: {0, 0}}, %Geo.Point{coordinates: {3, 4}})
-      5.0
-
-  """
+  @moduledoc false
 
   alias Geo
 

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -1,16 +1,5 @@
 defmodule GeoMeasure.Extent do
-  @moduledoc """
-  Calculates the extent of a Geo struct.
-
-  ## Examples:
-
-      iex> GeoMeasure.Extent.extent(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
-      {1, 3, 2, 4}
-
-      iex> GeoMeasure.Extent.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
-      {0, 2, 0, 2}
-
-  """
+  @moduledoc false
 
   @spec calculate_extent([{number(), number()}]) :: {number(), number(), number(), number()}
   def calculate_extent(coords) when is_list(coords) do
@@ -41,7 +30,6 @@ defmodule GeoMeasure.Extent do
   Calculates the extent coordinates of a Geo struct.
   """
   @doc since: "0.0.1"
-
   @spec extent(Geo.LineString.t()) :: {number(), number(), number(), number()}
   def extent(%Geo.LineString{coordinates: coords}) do
     calculate_extent(coords)

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -1,13 +1,5 @@
 defmodule GeoMeasure.Perimeter do
-  @moduledoc """
-  Calculates the perimeter of a Geo struct.
-
-  ## Examples:
-
-      iex> GeoMeasure.Perimeter.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
-      8.0
-
-  """
+  @moduledoc false
 
   alias GeoMeasure.Distance
 
@@ -33,7 +25,6 @@ defmodule GeoMeasure.Perimeter do
   Calculates the perimeter of a Geo struct.
   """
   @doc since: "0.0.1"
-
   @spec perimeter(Geo.Polygon.t()) :: float()
   def perimeter(%Geo.Polygon{coordinates: [coords]}) do
     calculate_perimeter(coords)


### PR DESCRIPTION
This PR aims to consolidate all module documentation in the GeoMeasure module as a decisive move to prefer the usage of the main module instead of highlighting the opportunity to call the functions from the submodules directly. While that is still possible, it will not show up prominently in documentation. This move will change the Hex documentation, as well as the README. It also shows a new table of supported properties for each geometry. This PR is the result of #4.