### PR TITLE
refactor: rename submodule functions to calculate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ end
 ```
 ## Examples
 
-While each function can be called through their module, such as `GeoMeasure.Area.area` or `GeoMeasure.Perimeter.perimeter`, it is encouraged to use delegates from the main `GeoMeasure` module, enabling shortened calls, such as `GeoMeasure.area` or `GeoMeasure.perimeter`. Thus, the following examples will only show the shorter, more convenient calls through `GeoMeasure`.
+While each function can be called through their module, such as `GeoMeasure.Area.calculate` or `GeoMeasure.Perimeter.calculate`, it is encouraged to use delegates from the main `GeoMeasure` module, enabling shortened calls, such as `GeoMeasure.area` or `GeoMeasure.perimeter`. Thus, the following examples will only show the shorter, more convenient calls through `GeoMeasure`.
 
 ### Area
 

--- a/lib/geomeasure.ex
+++ b/lib/geomeasure.ex
@@ -95,21 +95,21 @@ defmodule GeoMeasure do
   """
   @doc since: "0.0.1"
   @spec area(Geo.geometry()) :: number()
-  defdelegate area(geometry), to: Area
+  defdelegate area(geometry), to: Area, as: :calculate
 
   @doc """
   Calculates the bounding box of a Geo struct as a Geo.Polygon.
   """
   @doc since: "0.0.1"
   @spec bbox(Geo.geometry()) :: Geo.geometry()
-  defdelegate bbox(geometry), to: Bbox
+  defdelegate bbox(geometry), to: Bbox, as: :calculate
 
   @doc """
   Calculates the centroid of a Geo struct as a Geo.Point.
   """
   @doc since: "0.0.1"
   @spec centroid(Geo.geometry()) :: Geo.Point.t()
-  defdelegate centroid(geometry), to: Centroid
+  defdelegate centroid(geometry), to: Centroid, as: :calculate
 
   @doc """
   Calculates the distance between two coordinate pairs or Geo.Point structs.
@@ -117,19 +117,19 @@ defmodule GeoMeasure do
   @doc since: "0.0.1"
   @spec distance({number(), number()}, {number(), number()}) :: float()
   @spec distance(Geo.Point.t(), Geo.Point.t()) :: float()
-  defdelegate distance(coordinates_1, coordinates_2), to: Distance
+  defdelegate distance(coordinates_1, coordinates_2), to: Distance, as: :calculate
 
   @doc """
   Calculates the extent coordinates of a Geo struct.
   """
   @doc since: "0.0.1"
   @spec extent(Geo.geometry()) :: {number(), number(), number(), number()}
-  defdelegate extent(geometry), to: Extent
+  defdelegate extent(geometry), to: Extent, as: :calculate
 
   @doc """
   Calculates the perimeter of a Geo struct.
   """
   @doc since: "0.0.1"
   @spec perimeter(Geo.geometry()) :: float()
-  defdelegate perimeter(geometry), to: Perimeter
+  defdelegate perimeter(geometry), to: Perimeter, as: :calculate
 end

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -24,8 +24,8 @@ defmodule GeoMeasure.Area do
   Calculates the area of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec area(Geo.Polygon.t()) :: float()
-  def area(%Geo.Polygon{coordinates: [coords]}) do
+  @spec calculate(Geo.Polygon.t()) :: float()
+  def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_area(coords)
   end
 end

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -24,16 +24,16 @@ defmodule GeoMeasure.Bbox do
   Calculates the bounding box of a Geo struct as a Geo.Polygon.
   """
   @doc since: "0.0.1"
-  @spec bbox(Geo.Point.t()) :: Geo.Point.t()
-  def bbox(%Geo.Point{} = point), do: point
+  @spec calculate(Geo.Point.t()) :: Geo.Point.t()
+  def calculate(%Geo.Point{} = point), do: point
 
-  @spec bbox(Geo.LineString.t()) :: Geo.Polygon.t()
-  def bbox(%Geo.LineString{coordinates: coords}) do
+  @spec calculate(Geo.LineString.t()) :: Geo.Polygon.t()
+  def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_bbox(coords)
   end
 
-  @spec bbox(Geo.Polygon.t()) :: Geo.Polygon.t()
-  def bbox(%Geo.Polygon{coordinates: [coords]}) do
+  @spec calculate(Geo.Polygon.t()) :: Geo.Polygon.t()
+  def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_bbox(coords)
   end
 end

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -16,16 +16,16 @@ defmodule GeoMeasure.Centroid do
   Calculates the centroid of a Geo struct as a Geo.Point.
   """
   @doc since: "0.0.1"
-  @spec centroid(Geo.Point.t()) :: Geo.Point.t()
-  def centroid(%Geo.Point{} = point), do: point
+  @spec calculate(Geo.Point.t()) :: Geo.Point.t()
+  def calculate(%Geo.Point{} = point), do: point
 
-  @spec centroid(Geo.LineString.t()) :: Geo.Point.t()
-  def centroid(%Geo.LineString{coordinates: coords}) do
+  @spec calculate(Geo.LineString.t()) :: Geo.Point.t()
+  def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_centroid(coords)
   end
 
-  @spec centroid(Geo.Polygon.t()) :: Get.Point.t()
-  def centroid(%Geo.Polygon{coordinates: [coords]}) do
+  @spec calculate(Geo.Polygon.t()) :: Get.Point.t()
+  def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_centroid(tl(coords))
   end
 end

--- a/lib/geomeasure/distance.ex
+++ b/lib/geomeasure/distance.ex
@@ -7,13 +7,13 @@ defmodule GeoMeasure.Distance do
   Calculates the distance between two coordinate pairs or Geo.Point structs.
   """
   @doc since: "0.0.1"
-  @spec distance({number(), number()}, {number(), number()}) :: float()
-  def distance({x1, y1}, {x2, y2}) do
+  @spec calculate({number(), number()}, {number(), number()}) :: float()
+  def calculate({x1, y1}, {x2, y2}) do
     :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2))
   end
 
-  @spec distance(Geo.Point.t(), Geo.Point.t()) :: float()
-  def distance(%Geo.Point{coordinates: coord_1}, %Geo.Point{coordinates: coord_2}) do
-    distance(coord_1, coord_2)
+  @spec calculate(Geo.Point.t(), Geo.Point.t()) :: float()
+  def calculate(%Geo.Point{coordinates: coord_1}, %Geo.Point{coordinates: coord_2}) do
+    calculate(coord_1, coord_2)
   end
 end

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -30,13 +30,13 @@ defmodule GeoMeasure.Extent do
   Calculates the extent coordinates of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec extent(Geo.LineString.t()) :: {number(), number(), number(), number()}
-  def extent(%Geo.LineString{coordinates: coords}) do
+  @spec calculate(Geo.LineString.t()) :: {number(), number(), number(), number()}
+  def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_extent(coords)
   end
 
-  @spec extent(Geo.Polygon.t()) :: {number(), number(), number(), number()}
-  def extent(%Geo.Polygon{coordinates: [coords]}) do
+  @spec calculate(Geo.Polygon.t()) :: {number(), number(), number(), number()}
+  def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_extent(tl(coords))
   end
 end

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -10,11 +10,11 @@ defmodule GeoMeasure.Perimeter do
     |> Enum.reduce({0, tl(coords)}, fn point_1, {acc, remaining} ->
       case remaining do
         [point_2 = {_a, _b}] ->
-          acc = acc + Distance.distance(point_1, point_2)
+          acc = acc + Distance.calculate(point_1, point_2)
           {acc, []}
 
         [point_2 | rest] ->
-          acc = acc + Distance.distance(point_1, point_2)
+          acc = acc + Distance.calculate(point_1, point_2)
           {acc, rest}
       end
     end)
@@ -25,8 +25,8 @@ defmodule GeoMeasure.Perimeter do
   Calculates the perimeter of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec perimeter(Geo.Polygon.t()) :: float()
-  def perimeter(%Geo.Polygon{coordinates: [coords]}) do
+  @spec calculate(Geo.Polygon.t()) :: float()
+  def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_perimeter(coords)
   end
 end

--- a/test/geomeasure/area_test.exs
+++ b/test/geomeasure/area_test.exs
@@ -3,16 +3,16 @@ defmodule GeoMeasure.Area.Test do
 
   test "calculate_point_area" do
     geom = %Geo.Point{coordinates: {1, 2}}
-    assert_raise FunctionClauseError, fn -> GeoMeasure.Area.area(geom) end
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Area.calculate(geom) end
   end
 
   test "calculate_linestring_area" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
-    assert_raise FunctionClauseError, fn -> GeoMeasure.Area.area(geom) end
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Area.calculate(geom) end
   end
 
   test "calculate_polygon_area" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
-    assert GeoMeasure.Area.area(geom) == 4.0
+    assert GeoMeasure.Area.calculate(geom) == 4.0
   end
 end

--- a/test/geomeasure/bbox_test.exs
+++ b/test/geomeasure/bbox_test.exs
@@ -3,13 +3,13 @@ defmodule GeoMeasure.Bbox.Test do
 
   test "calculate_point_bbox" do
     geom = %Geo.Point{coordinates: {1, 2}}
-    assert GeoMeasure.Bbox.bbox(geom) == %Geo.Point{coordinates: {1, 2}}
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Point{coordinates: {1, 2}}
   end
 
   test "calculate_linestring_bbox" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
 
-    assert GeoMeasure.Bbox.bbox(geom) == %Geo.Polygon{
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
              coordinates: [[{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}]]
            }
   end
@@ -17,7 +17,7 @@ defmodule GeoMeasure.Bbox.Test do
   test "calculate_polygon_bbox" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
 
-    assert GeoMeasure.Bbox.bbox(geom) == %Geo.Polygon{
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]
            }
   end

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -3,16 +3,16 @@ defmodule GeoMeasure.Centroid.Test do
 
   test "calculate_point_centroid" do
     geom = %Geo.Point{coordinates: {1, 2}}
-    assert GeoMeasure.Centroid.centroid(geom) == %Geo.Point{coordinates: {1, 2}}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1, 2}}
   end
 
   test "calculate_linestring_centroid" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
-    assert GeoMeasure.Centroid.centroid(geom) == %Geo.Point{coordinates: {2.0, 3.0}}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {2.0, 3.0}}
   end
 
   test "calculate_polygon_centroid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
-    assert GeoMeasure.Centroid.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
   end
 end

--- a/test/geomeasure/distance_test.exs
+++ b/test/geomeasure/distance_test.exs
@@ -4,36 +4,36 @@ defmodule GeoMeasure.Distance.Test do
   test "calculate_distance_x_direction" do
     a = {0, 0}
     b = {5, 0}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 
   test "calculate_distance_y_direction" do
     a = {0, 0}
     b = {0, 5}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 
   test "calculate_distance_xy_direction" do
     a = {0, 0}
     b = {3, 4}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 
   test "calculate_distance_x_direction_point" do
     a = %Geo.Point{coordinates: {0, 0}}
     b = %Geo.Point{coordinates: {5, 0}}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 
   test "calculate_distance_y_direction_point" do
     a = %Geo.Point{coordinates: {0, 0}}
     b = %Geo.Point{coordinates: {0, 5}}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 
   test "calculate_distance_xy_direction_point" do
     a = %Geo.Point{coordinates: {0, 0}}
     b = %Geo.Point{coordinates: {3, 4}}
-    assert GeoMeasure.Distance.distance(a, b) == 5.0
+    assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
 end

--- a/test/geomeasure/extent_test.exs
+++ b/test/geomeasure/extent_test.exs
@@ -3,16 +3,16 @@ defmodule GeoMeasure.Extent.Test do
 
   test "calculate_point_extent" do
     geom = %Geo.Point{coordinates: {1, 2}}
-    assert_raise FunctionClauseError, fn -> GeoMeasure.Extent.extent(geom) end
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Extent.calculate(geom) end
   end
 
   test "calculate_linestring_extent" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
-    assert GeoMeasure.Extent.extent(geom) == {1, 3, 2, 4}
+    assert GeoMeasure.Extent.calculate(geom) == {1, 3, 2, 4}
   end
 
   test "calculate_polygon_extent" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
-    assert GeoMeasure.Extent.extent(geom) == {0, 2, 0, 2}
+    assert GeoMeasure.Extent.calculate(geom) == {0, 2, 0, 2}
   end
 end

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -3,16 +3,16 @@ defmodule GeoMeasure.Perimeter.Test do
 
   test "calculate_point_perimeter" do
     geom = %Geo.Point{coordinates: {1, 2}}
-    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.perimeter(geom) end
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 
   test "calculate_linestring_perimeter" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
-    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.perimeter(geom) end
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 
   test "calculate_polygon_perimeter" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
-    assert GeoMeasure.Perimeter.perimeter(geom) == 8.0
+    assert GeoMeasure.Perimeter.calculate(geom) == 8.0
   end
 end


### PR DESCRIPTION
This PR aims to provide uniformity between submodule functions by changing their name to calculate, instead of a lowercase version of their submodule name. This is also reflected in the README file.

BREAKING CHANGE: the functions in the submodules must be called as GeoMeasure.<submodule_name>.calculate from now on