### PR TITLE
feat: handle nil in geometries

### DIFF
--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -1,14 +1,18 @@
 defmodule GeoMeasure.Area do
   @moduledoc false
 
+  alias GeoMeasure.Utils
+
   @spec calculate_area([{number(), number()}]) :: float()
   defp calculate_area(coords) when is_list(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn item, accumulator ->
+      Utils.tuple_not_nil!(item)
       {x1, y1} = item
 
       case accumulator do
         {acc, [{x2, y2} | rest]} ->
+          Utils.tuple_not_nil!({x2, y2})
           acc = acc + abs(x1 * y2 - x2 * y1)
           {acc, [{x2, y2}] ++ rest}
 

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -1,7 +1,7 @@
 defmodule GeoMeasure.Bbox do
   @moduledoc false
 
-  alias GeoMeasure.Extent
+  alias GeoMeasure.{Extent, Utils}
 
   @spec calculate_bbox([{number(), number()}]) :: Geo.Polygon.t()
   defp calculate_bbox(coords) when is_list(coords) do
@@ -25,7 +25,10 @@ defmodule GeoMeasure.Bbox do
   """
   @doc since: "0.0.1"
   @spec calculate(Geo.Point.t()) :: Geo.Point.t()
-  def calculate(%Geo.Point{} = point), do: point
+  def calculate(%Geo.Point{coordinates: coords} = point) do
+    Utils.tuple_not_nil!(coords)
+    point
+  end
 
   @spec calculate(Geo.LineString.t()) :: Geo.Polygon.t()
   def calculate(%Geo.LineString{coordinates: coords}) do

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -2,10 +2,16 @@ defmodule GeoMeasure.Centroid do
   @moduledoc false
 
   alias Geo
+  alias GeoMeasure.Utils
 
   @spec calculate_centroid([{number(), number()}]) :: Geo.Point.t()
   defp calculate_centroid(coords) when is_list(coords) do
-    {sum_x, sum_y} = Enum.reduce(coords, {0, 0}, &sum_coordinates/2)
+    {sum_x, sum_y} =
+      Enum.reduce(coords, {0, 0}, fn tpl, acc ->
+        Utils.tuple_not_nil!(tpl)
+        sum_coordinates(acc, tpl)
+      end)
+
     mean_x = sum_x / length(coords)
     mean_y = sum_y / length(coords)
     %Geo.Point{coordinates: {mean_x, mean_y}}
@@ -19,7 +25,10 @@ defmodule GeoMeasure.Centroid do
   """
   @doc since: "0.0.1"
   @spec calculate(Geo.Point.t()) :: Geo.Point.t()
-  def calculate(%Geo.Point{} = point), do: point
+  def calculate(%Geo.Point{coordinates: coords} = point) do
+    Utils.tuple_not_nil!(coords)
+    point
+  end
 
   @spec calculate(Geo.LineString.t()) :: Geo.Point.t()
   def calculate(%Geo.LineString{coordinates: coords}) do

--- a/lib/geomeasure/distance.ex
+++ b/lib/geomeasure/distance.ex
@@ -2,6 +2,7 @@ defmodule GeoMeasure.Distance do
   @moduledoc false
 
   alias Geo
+  alias GeoMeasure.Utils
 
   @doc """
   Calculates the distance between two coordinate pairs or Geo.Point structs.
@@ -9,6 +10,8 @@ defmodule GeoMeasure.Distance do
   @doc since: "0.0.1"
   @spec calculate({number(), number()}, {number(), number()}) :: float()
   def calculate({x1, y1}, {x2, y2}) do
+    Utils.tuple_not_nil!({x1, y1})
+    Utils.tuple_not_nil!({x2, y2})
     :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2))
   end
 

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -1,10 +1,14 @@
 defmodule GeoMeasure.Extent do
   @moduledoc false
 
+  alias GeoMeasure.Utils
+
   @spec calculate_extent([{number(), number()}]) :: {number(), number(), number(), number()}
   def calculate_extent(coords) when is_list(coords) do
     coords
     |> Enum.reduce({nil, nil, nil, nil}, fn {x, y}, {min_x, max_x, min_y, max_y} ->
+      Utils.tuple_not_nil!({x, y})
+
       {
         min_x |> min_or_init(x),
         max_x |> max_or_init(x),

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,0 +1,16 @@
+defmodule GeoMeasure.Utils do
+  @moduledoc """
+  Contains utility functions to aid the correct handling of data in GeoMeasure.
+  """
+
+  @doc """
+  Checks if neither of the tuple elements is nil.
+  """
+  @doc since: "0.0.1"
+  @spec tuple_not_nil!({number() | nil, number() | nil}) :: ArgumentError
+  def tuple_not_nil!({x, y}) do
+    if is_nil(x) or is_nil(y) do
+      raise ArgumentError, message: "Tuple contains nil value: {#{inspect(x)}, #{inspect(y)}}"
+    end
+  end
+end

--- a/test/geomeasure/area_test.exs
+++ b/test/geomeasure/area_test.exs
@@ -15,4 +15,9 @@ defmodule GeoMeasure.Area.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Area.calculate(geom) == 4.0
   end
+
+  test "calculate_polygon_area_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Area.calculate(geom) end
+  end
 end

--- a/test/geomeasure/bbox_test.exs
+++ b/test/geomeasure/bbox_test.exs
@@ -21,4 +21,19 @@ defmodule GeoMeasure.Bbox.Test do
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]
            }
   end
+
+  test "calculate_point_bbox_nil_coord" do
+    geom = %Geo.Point{coordinates: {1, nil}}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
+
+  test "calculate_linestring_bbox_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
+
+  test "calculate_polygon_bbox_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
 end

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -15,4 +15,19 @@ defmodule GeoMeasure.Centroid.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
   end
+
+  test "calculate_point_centroid_nil_coord" do
+    geom = %Geo.Point{coordinates: {nil, 2}}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
+
+  test "calculate_linestring_centroid_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, nil}, {3, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
+
+  test "calculate_polygon_centroid_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, 2}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
 end

--- a/test/geomeasure/distance_test.exs
+++ b/test/geomeasure/distance_test.exs
@@ -36,4 +36,16 @@ defmodule GeoMeasure.Distance.Test do
     b = %Geo.Point{coordinates: {3, 4}}
     assert GeoMeasure.Distance.calculate(a, b) == 5.0
   end
+
+  test "calculate_distance_xy_direction_nil_coord" do
+    a = {0, nil}
+    b = {3, 4}
+    assert_raise ArgumentError, fn -> GeoMeasure.Distance.calculate(a, b) end
+  end
+
+  test "calculate_distance_xy_direction_point_nil_coord" do
+    a = %Geo.Point{coordinates: {0, 0}}
+    b = %Geo.Point{coordinates: {nil, 4}}
+    assert_raise ArgumentError, fn -> GeoMeasure.Distance.calculate(a, b) end
+  end
 end

--- a/test/geomeasure/extent_test.exs
+++ b/test/geomeasure/extent_test.exs
@@ -15,4 +15,14 @@ defmodule GeoMeasure.Extent.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Extent.calculate(geom) == {0, 2, 0, 2}
   end
+
+  test "calculate_linestring_extent_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
+  end
+
+  test "calculate_polygon_extent_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
+  end
 end

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -16,6 +16,11 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.area(geom) == 4.0
   end
 
+  test "calculate_polygon_area_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, nil}, {2, 2}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.area(geom) end
+  end
+
   test "calculate_point_bbox" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert GeoMeasure.bbox(geom) == %Geo.Point{coordinates: {1, 2}}
@@ -37,6 +42,21 @@ defmodule GeoMeasure.Test do
            }
   end
 
+  test "calculate_point_bbox_nil_coord" do
+    geom = %Geo.Point{coordinates: {1, nil}}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
+  test "calculate_linestring_bbox_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
+  test "calculate_polygon_bbox_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
   test "calculate_point_centroid" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1, 2}}
@@ -50,6 +70,21 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_centroid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
+  end
+
+  test "calculate_point_centroid_nil_coord" do
+    geom = %Geo.Point{coordinates: {nil, 2}}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
+  test "calculate_linestring_centroid_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, nil}, {3, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
+  test "calculate_polygon_centroid_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, 2}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
   end
 
   test "calculate_distance_x_direction" do
@@ -88,6 +123,18 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.distance(a, b) == 5.0
   end
 
+  test "calculate_distance_xy_direction_nil_coord" do
+    a = {0, nil}
+    b = {3, 4}
+    assert_raise ArgumentError, fn -> GeoMeasure.distance(a, b) end
+  end
+
+  test "calculate_distance_xy_direction_point_nil_coord" do
+    a = %Geo.Point{coordinates: {0, 0}}
+    b = %Geo.Point{coordinates: {nil, 4}}
+    assert_raise ArgumentError, fn -> GeoMeasure.distance(a, b) end
+  end
+
   test "calculate_point_extent" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert_raise FunctionClauseError, fn -> GeoMeasure.extent(geom) end
@@ -103,6 +150,16 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.extent(geom) == {0, 2, 0, 2}
   end
 
+  test "calculate_linestring_extent_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
+  end
+
+  test "calculate_polygon_extent_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
+  end
+
   test "calculate_point_perimeter" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert_raise FunctionClauseError, fn -> GeoMeasure.perimeter(geom) end
@@ -116,5 +173,10 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_perimeter" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.perimeter(geom) == 8.0
+  end
+
+  test "calculate_polygon_perimeter_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.perimeter(geom) end
   end
 end

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -15,4 +15,9 @@ defmodule GeoMeasure.Perimeter.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Perimeter.calculate(geom) == 8.0
   end
+
+  test "calculate_polygon_perimeter_nil_coord" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
 end


### PR DESCRIPTION
This PR aims to handle nil values in the geometries the package supports. Each nil value raises an ArgumentError.

BREAKING CHANGE: nil values in geometry raise ArgumentError