### PR TITLE
feat: partial support for LineStringZ and LineStringZM, length function, area bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.3.0 - 2025-05-24
+
+### Enhancements
+
+- [Added the GeoMeasure.length function to calculate the length of linear geometries](https://github.com/simagyari/geomeasure/pull/21). It uses the `Perimeter` module under the hood, but the `length` name keeps the geometric correctness.
+- [Added support for Geo.LineStringZ and Geo.LineStringZM structs except for GeoMeasure.bbox](https://github.com/simagyari/geomeasure/pull/21). This involves the `centroid`, `extent`, and `length` functions. Please refer to the [documentation](https://github.com/simagyari/geomeasure/blob/main/README.md) for more information.
+
+### Bug fixes
+
+- [Fixed the way GeoMeasure.area calculates the area of concave polygons](https://github.com/simagyari/geomeasure/pull/21).
+
 ## v1.2.0 - 2025-04-07
 
 ### Enhancements
@@ -34,9 +45,9 @@ This ensures that the package raises a uniform ArgumentError upon encountering `
 
 ## v0.0.1 - 2025-03-21
 
-- First publication of the package
+### First publication of the package
 
-- Enhancements
+### Enhancements
 
-    - Created functions for the calculation of the supported properties (area, bounding box, centroid, distance, extent, perimeter) for the supported structs (Point, LineString, Polygon)
-    - Added convenience shortcuts from the main GeoMeasure module in the form of delegates to the specific modules containing the actual functions.
+- Created functions for the calculation of the supported properties (area, bounding box, centroid, distance, extent, perimeter) for the supported structs (Point, LineString, Polygon)
+- Added convenience shortcuts from the main GeoMeasure module in the form of delegates to the specific modules containing the actual functions.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _Note_: If you would like to make in-memory calculations to determine the relati
 ```elixir
 defp deps do
   [
-    {:geomeasure, "~> 1.2.0"}
+    {:geomeasure, "~> 1.3.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Currently, this project supports only the following geometries:
 - PointZ
 - PointZM
 - LineString
-- LineStringZ
-- LineStringZM
+- LineStringZ (partial support)
+- LineStringZM (partial support)
 - Polygon
 
 Currently, the following properties can be calculated for the supported [Geo](https://github.com/felt/geo/tree/master) structs:
@@ -114,7 +114,13 @@ iex(4)> GeoMeasure.centroid(%Geo.PointZM{coordinates: 1, 2, 5, 8})
 iex(5)> GeoMeasure.centroid(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
 %Geo.Point{coordinates: {2.0, 3.0}, srid: nil, properties: %{}}
 
-iex(6)> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+iex(6)> GeoMeasure.centroid(%Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]})
+%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+
+iex(7)> GeoMeasure.centroid(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]})
+%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+
+iex(8)> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 %Geo.Point{coordinates: {1.0, 1.0}, srid: nil, properties: %{}}
 ```
 
@@ -155,14 +161,29 @@ iex(9)> GeoMeasure.distance(%Geo.PointZM{coordinates: {0, 0, 0, 8}}, %Geo.PointZ
 iex(1)> GeoMeasure.extent(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
 {1, 3, 2, 4}
 
-iex(2)> GeoMeasure.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+iex(2)> GeoMeasure.extent(%Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]})
+{1, 3, 2, 4, 3, 5}
+
+iex(3)> GeoMeasure.extent(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]})
+{1, 3, 2, 4, 3, 5}
+
+iex(4)> GeoMeasure.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 {0, 2, 0, 2}
 ```
 
-### Perimeter
+### Perimeter/Length
 
 ```elixir
-iex(1)> GeoMeasure.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+iex(1)> GeoMeasure.length(%Geo.LineString{coordinates: [{1, 2}, {1, 4}]})
+2.0
+
+iex(2)> GeoMeasure.length(%Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, 4, 2}]})
+2.0
+
+iex(3)> GeoMeasure.length(%Geo.LineStringZM{coordinates: [{1, 2, 2, 10}, {1, 4, 2, 11}]})
+2.0
+
+iex(4)> GeoMeasure.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 8.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@ Currently, the following properties can be calculated for the supported [Geo](ht
 
 For each geometry, only the properties that have meaning for the given geometry are implemented. This results in the following implementation table, where ✅ means supported, and ❌ means unsupported property:
 
-| Geometry   | Area | Bounding box | Centroid | Distance | Extent | Perimeter |
-| ---------- | :--: | :----------: | :------: | :------: | :----: | :-------: |
-| Point      | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointM     | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointZ     | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointZM    | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| LineString | ❌   | ✅          | ✅       | ❌      | ✅     | ❌       |
-| Polygon    | ✅   | ✅          | ✅       | ❌      | ✅     | ✅       |
+| Geometry     | Area | Bounding box | Centroid | Distance | Extent | Perimeter |
+| ----------   | :--: | :----------: | :------: | :------: | :----: | :-------: |
+| Point        | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
+| PointM       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
+| PointZ       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
+| PointZM      | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
+| LineString   | ❌   | ✅          | ✅       | ❌      | ✅     | ❌       |
+| LineStringZ  | ❌   | 🔶          | ✅       | ❌      | ✅     | ❌       |
+| LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ❌       |
+| Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ✅       |
 
 _Note_: If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Currently, this project supports only the following geometries:
 - PointZ
 - PointZM
 - LineString
+- LineStringZ
+- LineStringZM
 - Polygon
 
 Currently, the following properties can be calculated for the supported [Geo](https://github.com/felt/geo/tree/master) structs:
@@ -25,20 +27,24 @@ Currently, the following properties can be calculated for the supported [Geo](ht
 - Centroid
 - Distance (between two coordinate pairs or Geo.Point(M) structs)
 - Extent
-- Perimeter
+- Length/Perimeter
 
-For each geometry, only the properties that have meaning for the given geometry are implemented. This results in the following implementation table, where ✅ means supported, and ❌ means unsupported property:
+For each geometry, only the properties that have meaning for the given geometry are implemented. This results in the following implementation table, where ✅ means supported, and ❌ means unsupported property, while 🔶 means incomplete or in progress support for a property:
 
-| Geometry     | Area | Bounding box | Centroid | Distance | Extent | Perimeter |
-| ----------   | :--: | :----------: | :------: | :------: | :----: | :-------: |
-| Point        | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointM       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointZ       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| PointZM      | ❌   | ✅          | ✅       | ✅      | ❌     | ❌       |
-| LineString   | ❌   | ✅          | ✅       | ❌      | ✅     | ❌       |
-| LineStringZ  | ❌   | 🔶          | ✅       | ❌      | ✅     | ❌       |
-| LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ❌       |
-| Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ✅       |
+| Geometry     | Area | Bounding box | Centroid | Distance | Extent | Length | Perimeter |
+| ----------   | :--: | :----------: | :------: | :------: | :----: | :----: | :-------: |
+| Point        | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
+| PointM       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
+| PointZ       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
+| PointZM      | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
+| LineString   | ❌   | ✅          | ✅       | ❌      | ✅     | ✅    | ❌        |
+| LineStringZ  | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
+| LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
+| Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ❌    | ✅        |
+
+_Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
+
+_Note_: Currently only simple polygons are supported for the area calculations.
 
 _Note_: If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
 

--- a/lib/geomeasure.ex
+++ b/lib/geomeasure.ex
@@ -56,6 +56,12 @@ defmodule GeoMeasure do
       iex> GeoMeasure.centroid(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
       %Geo.Point{coordinates: {2.0, 3.0}}
 
+      iex> GeoMeasure.centroid(%Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]})
+      %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+
+      iex> GeoMeasure.centroid(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]})
+      %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+
       iex> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
       %Geo.Point{coordinates: {1.0, 1.0}}
 
@@ -101,14 +107,29 @@ defmodule GeoMeasure do
       iex> GeoMeasure.extent(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
       {1, 3, 2, 4}
 
+      iex> GeoMeasure.extent(%Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]})
+      {1, 3, 2, 4, 3, 5}
+
+      iex> GeoMeasure.extent(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]})
+      {1, 3, 2, 4, 3, 5}
+
       iex> GeoMeasure.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
       {0, 2, 0, 2}
 
-  ## perimeter
+  ## perimeter/length
 
-  Calculates the perimeter of a Geo struct.
+  Calculates the perimeter or length of a Geo struct.
 
   #### Examples:
+
+      iex> GeoMeasure.length(%Geo.LineString{coordinates: [{1, 2}, {1, 4}]})
+      2.0
+
+      iex> GeoMeasure.length(%Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, 4, 2}]})
+      2.0
+
+      iex> GeoMeasure.length(%Geo.LineStringZM{coordinates: [{1, 2, 2, 10}, {1, 4, 2, 11}]})
+      2.0
 
       iex> GeoMeasure.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
       8.0

--- a/lib/geomeasure.ex
+++ b/lib/geomeasure.ex
@@ -127,33 +127,34 @@ defmodule GeoMeasure do
   }
 
   @type geo_point :: Geo.Point.t() | Geo.PointM.t() | Geo.PointZ.t() | Geo.PointZM.t()
+  @type geo_line :: Geo.LineString.t() | Geo.LineStringZ.t() | Geo.LineStringZM.t()
 
   @doc """
   Calculates the area of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec area(Geo.geometry()) :: number()
+  @spec area(Geo.geometry()) :: float
   defdelegate area(geometry), to: Area, as: :calculate
 
   @doc """
   Calculates the bounding box of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec bbox(Geo.geometry()) :: Geo.geometry()
+  @spec bbox(Geo.geometry()) :: Geo.Point.t() | Geo.PointZ.t() | Geo.Polygon.t()
   defdelegate bbox(geometry), to: Bbox, as: :calculate
 
   @doc """
   Calculates the centroid of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec centroid(Geo.geometry()) :: Geo.Point.t()
+  @spec centroid(Geo.geometry()) :: Geo.Point.t() | Geo.PointZ.t()
   defdelegate centroid(geometry), to: Centroid, as: :calculate
 
   @doc """
   Calculates the distance between two coordinate pairs or points.
   """
   @doc since: "0.0.1"
-  @spec distance({number(), number()}, {number(), number()}) :: float()
+  @spec distance({number(), number()}, {number(), number()}) :: float
   @spec distance(geo_point(), geo_point()) :: float()
   defdelegate distance(coordinates_1, coordinates_2), to: Distance, as: :calculate
 
@@ -161,13 +162,20 @@ defmodule GeoMeasure do
   Calculates the extent coordinates of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec extent(Geo.geometry()) :: {number(), number(), number(), number()}
+  @spec extent(Geo.geometry()) :: {number, number, number, number}
   defdelegate extent(geometry), to: Extent, as: :calculate
 
   @doc """
-  Calculates the perimeter of a Geo struct.
+  Calculates the length of a linear Geo struct.
+  """
+  @doc since: "1.3.0"
+  @spec length(geo_line()) :: float
+  defdelegate length(geometry), to: Perimeter, as: :calculate
+
+  @doc """
+  Calculates the perimeter of a polygonal Geo struct.
   """
   @doc since: "0.0.1"
-  @spec perimeter(Geo.geometry()) :: float()
+  @spec perimeter(Geo.Polygon.t()) :: float
   defdelegate perimeter(geometry), to: Perimeter, as: :calculate
 end

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -3,24 +3,24 @@ defmodule GeoMeasure.Area do
 
   alias GeoMeasure.Utils
 
-  @spec calculate_area([{number(), number()}]) :: float()
+  @spec calculate_area([{number, number}]) :: float
   defp calculate_area(coords) when is_list(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn item, accumulator ->
       Utils.tuple_not_nil!(item)
+      IO.inspect({item, accumulator})
       {x1, y1} = item
 
       case accumulator do
         {acc, [{x2, y2} | rest]} ->
           Utils.tuple_not_nil!({x2, y2})
-          acc = acc + abs(x1 * y2 - x2 * y1)
-          {acc, [{x2, y2}] ++ rest}
+          acc = acc + x1 * y2 - x2 * y1
+          {acc, rest}
 
-        {acc, [{_}]} ->
-          {acc}
+        {acc, []} -> acc
       end
     end)
-    |> elem(0)
+    |> abs()
     |> Kernel./(2)
   end
 
@@ -28,7 +28,7 @@ defmodule GeoMeasure.Area do
   Calculates the area of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec calculate(Geo.Polygon.t()) :: float()
+  @spec calculate(Geo.Polygon.t()) :: float
   def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_area(coords)
   end

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -16,7 +16,8 @@ defmodule GeoMeasure.Area do
           acc = acc + x1 * y2 - x2 * y1
           {acc, rest}
 
-        {acc, []} -> acc
+        {acc, []} ->
+          acc
       end
     end)
     |> abs()

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -4,11 +4,10 @@ defmodule GeoMeasure.Area do
   alias GeoMeasure.Utils
 
   @spec calculate_area([{number, number}]) :: float
-  defp calculate_area(coords) when is_list(coords) do
+  defp calculate_area(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn item, accumulator ->
       Utils.tuple_not_nil!(item)
-      IO.inspect({item, accumulator})
       {x1, y1} = item
 
       case accumulator do

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -3,7 +3,7 @@ defmodule GeoMeasure.Bbox do
 
   alias GeoMeasure.{Extent, Utils}
 
-  @spec calculate_bbox([{number(), number()}]) :: Geo.Polygon.t()
+  @spec calculate_bbox([{number, number}]) :: Geo.Polygon.t()
   defp calculate_bbox(coords) when is_list(coords) do
     {min_x, max_x, min_y, max_y} = Extent.calculate_extent(coords)
 

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -4,7 +4,7 @@ defmodule GeoMeasure.Bbox do
   alias GeoMeasure.{Extent, Utils}
 
   @spec calculate_bbox([{number, number}]) :: Geo.Polygon.t()
-  defp calculate_bbox(coords) when is_list(coords) do
+  defp calculate_bbox(coords) do
     {min_x, max_x, min_y, max_y} = Extent.calculate_extent(coords)
 
     %Geo.Polygon{

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -34,7 +34,8 @@ defmodule GeoMeasure.Centroid do
   @spec sum_coordinates({number, number}, {number, number}) :: {number, number}
   defp sum_coordinates({lx, ly}, {rx, ry}), do: {lx + rx, ly + ry}
 
-  @spec sum_coordinates({number, number, number}, {number, number, number}) :: {number, number, number}
+  @spec sum_coordinates({number, number, number}, {number, number, number}) ::
+          {number, number, number}
   defp sum_coordinates({lx, ly, lz}, {rx, ry, rz}), do: {lx + rx, ly + ry, lz + rz}
 
   @doc """

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -17,8 +17,25 @@ defmodule GeoMeasure.Centroid do
     %Geo.Point{coordinates: {mean_x, mean_y}}
   end
 
-  @spec sum_coordinates({number(), number()}, {number(), number()}) :: number()
+  @spec calculate_centroid([{number(), number(), number()}]) :: Geo.PointZ.t()
+  defp calculate_centroid(coords) when is_list(coords) do
+    {sum_x, sum_y, sum_z} =
+      Enum.reduce(coords, {0, 0, 0}, fn tpl, acc ->
+        Utils.tuple_not_nil!(tpl)
+        sum_coordinates(acc, tpl)
+      end)
+
+    mean_x = sum_x / length(coords)
+    mean_y = sum_y / length(coords)
+    mean_z = sum_z / length(coords)
+    %Geo.PointZ{coordinates: {mean_x, mean_y, mean_z}}
+  end
+
+  @spec sum_coordinates({number(), number()}, {number(), number()}) :: {number(), number()}
   defp sum_coordinates({lx, ly}, {rx, ry}), do: {lx + rx, ly + ry}
+
+  @spec sum_coordinates({number(), number(), number()}, {number(), number(), number()}) :: {number(), number(), number()}
+  defp sum_coordinates({lx, ly, lz}, {rx, ry, rz}), do: {lx + rx, ly + ry, lz + rz}
 
   @doc """
   Calculates the centroid of a Geo struct.
@@ -51,6 +68,17 @@ defmodule GeoMeasure.Centroid do
   @spec calculate(Geo.LineString.t()) :: Geo.Point.t()
   def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_centroid(coords)
+  end
+
+  @spec calculate(Geo.LineStringZ.t()) :: Geo.PointZ.t()
+  def calculate(%Geo.LineStringZ{coordinates: coords}) do
+    calculate_centroid(coords)
+  end
+
+  @spec calculate(Geo.LineStringZM.t()) :: Geo.PointZ.t()
+  def calculate(%Geo.LineStringZM{coordinates: coords}) do
+    trimmed_coords = Enum.map(coords, fn {x, y, z, _} -> {x, y, z} end)
+    calculate_centroid(trimmed_coords)
   end
 
   @spec calculate(Geo.Polygon.t()) :: Get.Point.t()

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -5,7 +5,7 @@ defmodule GeoMeasure.Centroid do
   alias GeoMeasure.Utils
 
   @spec calculate_centroid([{number, number}]) :: Geo.Point.t()
-  defp calculate_centroid(coords) when is_list(coords) do
+  defp calculate_centroid(coords) do
     {sum_x, sum_y} =
       Enum.reduce(coords, {0, 0}, fn tpl, acc ->
         Utils.tuple_not_nil!(tpl)
@@ -17,8 +17,8 @@ defmodule GeoMeasure.Centroid do
     %Geo.Point{coordinates: {mean_x, mean_y}}
   end
 
-  @spec calculate_centroid([{number, number, number}]) :: Geo.PointZ.t()
-  defp calculate_centroid(coords) when is_list(coords) do
+  @spec calculate_centroid_3d([{number, number, number}]) :: Geo.PointZ.t()
+  defp calculate_centroid_3d(coords) do
     {sum_x, sum_y, sum_z} =
       Enum.reduce(coords, {0, 0, 0}, fn tpl, acc ->
         Utils.tuple_not_nil!(tpl)
@@ -72,13 +72,14 @@ defmodule GeoMeasure.Centroid do
 
   @spec calculate(Geo.LineStringZ.t()) :: Geo.PointZ.t()
   def calculate(%Geo.LineStringZ{coordinates: coords}) do
-    calculate_centroid(coords)
+    calculate_centroid_3d(coords)
   end
 
   @spec calculate(Geo.LineStringZM.t()) :: Geo.PointZ.t()
   def calculate(%Geo.LineStringZM{coordinates: coords}) do
-    trimmed_coords = Enum.map(coords, fn {x, y, z, _} -> {x, y, z} end)
-    calculate_centroid(trimmed_coords)
+    coords
+    |> Utils.remove_m_values()
+    |> calculate_centroid_3d()
   end
 
   @spec calculate(Geo.Polygon.t()) :: Get.Point.t()

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -4,7 +4,7 @@ defmodule GeoMeasure.Centroid do
   alias Geo
   alias GeoMeasure.Utils
 
-  @spec calculate_centroid([{number(), number()}]) :: Geo.Point.t()
+  @spec calculate_centroid([{number, number}]) :: Geo.Point.t()
   defp calculate_centroid(coords) when is_list(coords) do
     {sum_x, sum_y} =
       Enum.reduce(coords, {0, 0}, fn tpl, acc ->
@@ -17,7 +17,7 @@ defmodule GeoMeasure.Centroid do
     %Geo.Point{coordinates: {mean_x, mean_y}}
   end
 
-  @spec calculate_centroid([{number(), number(), number()}]) :: Geo.PointZ.t()
+  @spec calculate_centroid([{number, number, number}]) :: Geo.PointZ.t()
   defp calculate_centroid(coords) when is_list(coords) do
     {sum_x, sum_y, sum_z} =
       Enum.reduce(coords, {0, 0, 0}, fn tpl, acc ->
@@ -31,10 +31,10 @@ defmodule GeoMeasure.Centroid do
     %Geo.PointZ{coordinates: {mean_x, mean_y, mean_z}}
   end
 
-  @spec sum_coordinates({number(), number()}, {number(), number()}) :: {number(), number()}
+  @spec sum_coordinates({number, number}, {number, number}) :: {number, number}
   defp sum_coordinates({lx, ly}, {rx, ry}), do: {lx + rx, ly + ry}
 
-  @spec sum_coordinates({number(), number(), number()}, {number(), number(), number()}) :: {number(), number(), number()}
+  @spec sum_coordinates({number, number, number}, {number, number, number}) :: {number, number, number}
   defp sum_coordinates({lx, ly, lz}, {rx, ry, rz}), do: {lx + rx, ly + ry, lz + rz}
 
   @doc """

--- a/lib/geomeasure/distance.ex
+++ b/lib/geomeasure/distance.ex
@@ -8,58 +8,58 @@ defmodule GeoMeasure.Distance do
   Calculates the distance between two coordinate pairs or Geo.Point structs.
   """
   @doc since: "0.0.1"
-  @spec calculate({number(), number()}, {number(), number()}) :: float()
+  @spec calculate({number, number}, {number, number}) :: float
   def calculate({x1, y1}, {x2, y2}) do
     Utils.tuple_not_nil!({x1, y1})
     Utils.tuple_not_nil!({x2, y2})
     :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2))
   end
 
-  @spec calculate({number(), number(), number()}, {number(), number(), number()}) :: float()
+  @spec calculate({number, number, number}, {number, number, number}) :: float
   def calculate({x1, y1, z1}, {x2, y2, z2}) do
     Utils.tuple_not_nil!({x1, y1, z1})
     Utils.tuple_not_nil!({x2, y2, z2})
     :math.sqrt(:math.pow(x2 - x1, 2) + :math.pow(y2 - y1, 2) + :math.pow(z2 - z1, 2))
   end
 
-  @spec calculate(Geo.Point.t(), Geo.Point.t()) :: float()
+  @spec calculate(Geo.Point.t(), Geo.Point.t()) :: float
   def calculate(%Geo.Point{coordinates: coord_1}, %Geo.Point{coordinates: coord_2}) do
     calculate(coord_1, coord_2)
   end
 
-  @spec calculate(Geo.PointM.t(), Geo.PointM.t()) :: float()
+  @spec calculate(Geo.PointM.t(), Geo.PointM.t()) :: float
   def calculate(%Geo.PointM{coordinates: {x1, y1, _m1}}, %Geo.PointM{coordinates: {x2, y2, _m2}}) do
     calculate({x1, y1}, {x2, y2})
   end
 
-  @spec calculate(Geo.Point.t(), Geo.PointM.t()) :: float()
+  @spec calculate(Geo.Point.t(), Geo.PointM.t()) :: float
   def calculate(%Geo.Point{coordinates: coord1}, %Geo.PointM{coordinates: {x2, y2, _m2}}) do
     calculate(coord1, {x2, y2})
   end
 
-  @spec calculate(Geo.PointM.t(), Geo.Point.t()) :: float()
+  @spec calculate(Geo.PointM.t(), Geo.Point.t()) :: float
   def calculate(%Geo.PointM{coordinates: {x1, y1, _m1}}, %Geo.Point{coordinates: coord2}) do
     calculate({x1, y1}, coord2)
   end
 
-  @spec calculate(Geo.PointZ.t(), Geo.PointZ.t()) :: float()
+  @spec calculate(Geo.PointZ.t(), Geo.PointZ.t()) :: float
   def calculate(%Geo.PointZ{coordinates: coord1}, %Geo.PointZ{coordinates: coord2}) do
     calculate(coord1, coord2)
   end
 
-  @spec calculate(Geo.PointZM.t(), Geo.PointZM.t()) :: float()
+  @spec calculate(Geo.PointZM.t(), Geo.PointZM.t()) :: float
   def calculate(%Geo.PointZM{coordinates: {x1, y1, z1, _m1}}, %Geo.PointZM{
         coordinates: {x2, y2, z2, _m2}
       }) do
     calculate({x1, y1, z1}, {x2, y2, z2})
   end
 
-  @spec calculate(Geo.PointZ.t(), Geo.PointZM.t()) :: float()
+  @spec calculate(Geo.PointZ.t(), Geo.PointZM.t()) :: float
   def calculate(%Geo.PointZ{coordinates: coord1}, %Geo.PointZM{coordinates: {x2, y2, z2, _m2}}) do
     calculate(coord1, {x2, y2, z2})
   end
 
-  @spec calculate(Geo.PointZM.t(), Geo.PointZ.t()) :: float()
+  @spec calculate(Geo.PointZM.t(), Geo.PointZ.t()) :: float
   def calculate(%Geo.PointZM{coordinates: {x1, y1, z1, _m1}}, %Geo.PointZ{coordinates: coord2}) do
     calculate({x1, y1, z1}, coord2)
   end

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -3,7 +3,7 @@ defmodule GeoMeasure.Extent do
 
   alias GeoMeasure.Utils
 
-  @spec calculate_extent([{number(), number()}]) :: {number(), number(), number(), number()}
+  @spec calculate_extent([{number, number}]) :: {number, number, number, number}
   def calculate_extent(coords) when is_list(coords) do
     coords
     |> Enum.reduce({nil, nil, nil, nil}, fn {x, y}, {min_x, max_x, min_y, max_y} ->
@@ -18,7 +18,7 @@ defmodule GeoMeasure.Extent do
     end)
   end
 
-  @spec calculate_extent([{number(), number(), number()}]) :: {number(), number(), number(), number(), number(), number()}
+  @spec calculate_extent([{number, number, number}]) :: {number, number, number, number, number, number}
   def calculate_extent(coords) when is_list(coords) do
     coords
     |> Enum.reduce({nil, nil, nil, nil, nil, nil}, fn {x, y, z}, {min_x, max_x, min_y, max_y, min_z, max_z} ->
@@ -35,39 +35,39 @@ defmodule GeoMeasure.Extent do
     end)
   end
 
-  @spec min_or_init(nil, number()) :: number() | nil
+  @spec min_or_init(nil, number) :: number | nil
   defp min_or_init(nil, val), do: val
 
-  @spec min_or_init(number(), number()) :: number()
+  @spec min_or_init(number, number) :: number
   defp min_or_init(current, val), do: min(current, val)
 
-  @spec max_or_init(nil, number()) :: number() | nil
+  @spec max_or_init(nil, number) :: number | nil
   defp max_or_init(nil, val), do: val
 
-  @spec max_or_init(number(), number()) :: number()
+  @spec max_or_init(number, number) :: number
   defp max_or_init(current, val), do: max(current, val)
 
   @doc """
   Calculates the extent coordinates of a Geo struct.
   """
   @doc since: "0.0.1"
-  @spec calculate(Geo.LineString.t()) :: {number(), number(), number(), number()}
+  @spec calculate(Geo.LineString.t()) :: {number, number, number, number}
   def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_extent(coords)
   end
 
-  @spec calculate(Geo.LineStringZ.t()) :: {number(), number(), number(), number(), number(), number()}
+  @spec calculate(Geo.LineStringZ.t()) :: {number, number, number, number, number, number}
   def calculate(%Geo.LineStringZ{coordinates: coords}) do
     calculate_extent(coords)
   end
 
-  @spec calculate(Geo.LineStringZM.t()) :: {number(), number(), number(), number(), number(), number()}
+  @spec calculate(Geo.LineStringZM.t()) :: {number, number, number, number, number, number}
   def calculate(%Geo.LineStringZM{coordinates: coords}) do
     trimmed_coords = Enum.map(coords, fn {x, y, z, _} -> {x, y, z} end)
     calculate_extent(trimmed_coords)
   end
 
-  @spec calculate(Geo.Polygon.t()) :: {number(), number(), number(), number()}
+  @spec calculate(Geo.Polygon.t()) :: {number, number, number, number}
   def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_extent(tl(coords))
   end

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -18,6 +18,23 @@ defmodule GeoMeasure.Extent do
     end)
   end
 
+  @spec calculate_extent([{number(), number(), number()}]) :: {number(), number(), number(), number(), number(), number()}
+  def calculate_extent(coords) when is_list(coords) do
+    coords
+    |> Enum.reduce({nil, nil, nil, nil, nil, nil}, fn {x, y, z}, {min_x, max_x, min_y, max_y, min_z, max_z} ->
+      Utils.tuple_not_nil!({x, y, z})
+
+      {
+        min_x |> min_or_init(x),
+        max_x |> max_or_init(x),
+        min_y |> min_or_init(y),
+        max_y |> max_or_init(y),
+        min_z |> min_or_init(z),
+        max_z |> max_or_init(z)
+      }
+    end)
+  end
+
   @spec min_or_init(nil, number()) :: number() | nil
   defp min_or_init(nil, val), do: val
 
@@ -37,6 +54,17 @@ defmodule GeoMeasure.Extent do
   @spec calculate(Geo.LineString.t()) :: {number(), number(), number(), number()}
   def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_extent(coords)
+  end
+
+  @spec calculate(Geo.LineStringZ.t()) :: {number(), number(), number(), number(), number(), number()}
+  def calculate(%Geo.LineStringZ{coordinates: coords}) do
+    calculate_extent(coords)
+  end
+
+  @spec calculate(Geo.LineStringZM.t()) :: {number(), number(), number(), number(), number(), number()}
+  def calculate(%Geo.LineStringZM{coordinates: coords}) do
+    trimmed_coords = Enum.map(coords, fn {x, y, z, _} -> {x, y, z} end)
+    calculate_extent(trimmed_coords)
   end
 
   @spec calculate(Geo.Polygon.t()) :: {number(), number(), number(), number()}

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -4,7 +4,7 @@ defmodule GeoMeasure.Extent do
   alias GeoMeasure.Utils
 
   @spec calculate_extent([{number, number}]) :: {number, number, number, number}
-  def calculate_extent(coords) when is_list(coords) do
+  def calculate_extent(coords) do
     coords
     |> Enum.reduce({nil, nil, nil, nil}, fn {x, y}, {min_x, max_x, min_y, max_y} ->
       Utils.tuple_not_nil!({x, y})
@@ -18,8 +18,8 @@ defmodule GeoMeasure.Extent do
     end)
   end
 
-  @spec calculate_extent([{number, number, number}]) :: {number, number, number, number, number, number}
-  def calculate_extent(coords) when is_list(coords) do
+  @spec calculate_extent_3d([{number, number, number}]) :: {number, number, number, number, number, number}
+  def calculate_extent_3d(coords) do
     coords
     |> Enum.reduce({nil, nil, nil, nil, nil, nil}, fn {x, y, z}, {min_x, max_x, min_y, max_y, min_z, max_z} ->
       Utils.tuple_not_nil!({x, y, z})
@@ -58,13 +58,14 @@ defmodule GeoMeasure.Extent do
 
   @spec calculate(Geo.LineStringZ.t()) :: {number, number, number, number, number, number}
   def calculate(%Geo.LineStringZ{coordinates: coords}) do
-    calculate_extent(coords)
+    calculate_extent_3d(coords)
   end
 
   @spec calculate(Geo.LineStringZM.t()) :: {number, number, number, number, number, number}
   def calculate(%Geo.LineStringZM{coordinates: coords}) do
-    trimmed_coords = Enum.map(coords, fn {x, y, z, _} -> {x, y, z} end)
-    calculate_extent(trimmed_coords)
+    coords
+    |> Utils.remove_m_values()
+    |> calculate_extent_3d()
   end
 
   @spec calculate(Geo.Polygon.t()) :: {number, number, number, number}

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -18,10 +18,12 @@ defmodule GeoMeasure.Extent do
     end)
   end
 
-  @spec calculate_extent_3d([{number, number, number}]) :: {number, number, number, number, number, number}
+  @spec calculate_extent_3d([{number, number, number}]) ::
+          {number, number, number, number, number, number}
   def calculate_extent_3d(coords) do
     coords
-    |> Enum.reduce({nil, nil, nil, nil, nil, nil}, fn {x, y, z}, {min_x, max_x, min_y, max_y, min_z, max_z} ->
+    |> Enum.reduce({nil, nil, nil, nil, nil, nil}, fn {x, y, z},
+                                                      {min_x, max_x, min_y, max_y, min_z, max_z} ->
       Utils.tuple_not_nil!({x, y, z})
 
       {

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -3,7 +3,7 @@ defmodule GeoMeasure.Perimeter do
 
   alias GeoMeasure.{Distance, Utils}
 
-  @spec calculate_perimeter([{number(), number()}]) :: float()
+  @spec calculate_perimeter([{number, number}]) :: float
   defp calculate_perimeter(coords) when is_list(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn point_1, {acc, remaining} ->
@@ -28,24 +28,24 @@ defmodule GeoMeasure.Perimeter do
   """
   @doc since: "0.0.1"
 
-  @spec calculate(Geo.LineString.t()) :: float()
+  @spec calculate(Geo.LineString.t()) :: float
   def calculate(%Geo.LineString{coordinates: coords}) do
     calculate_perimeter(coords)
   end
 
-  @spec calculate(Geo.LineStringZ.t()) :: float()
+  @spec calculate(Geo.LineStringZ.t()) :: float
   def calculate(%Geo.LineStringZ{coordinates: coords}) do
     calculate_perimeter(coords)
   end
 
-  @spec calculate(Geo.LineStringZM.t()) :: float()
+  @spec calculate(Geo.LineStringZM.t()) :: float
   def calculate(%Geo.LineStringZM{coordinates: coords}) do
     coords
     |> Utils.remove_m_values()
     |> calculate_perimeter()
   end
 
-  @spec calculate(Geo.Polygon.t()) :: float()
+  @spec calculate(Geo.Polygon.t()) :: float
   def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_perimeter(coords)
   end

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -1,14 +1,17 @@
 defmodule GeoMeasure.Perimeter do
   @moduledoc false
 
-  alias GeoMeasure.Distance
+  alias GeoMeasure.{Distance, Utils}
 
   @spec calculate_perimeter([{number(), number()}]) :: float()
   defp calculate_perimeter(coords) when is_list(coords) do
     coords
-    |> Enum.drop(-1)
     |> Enum.reduce({0, tl(coords)}, fn point_1, {acc, remaining} ->
+      IO.inspect({point_1, remaining, acc})
       case remaining do
+        [] ->
+          acc
+
         [point_2 = {_a, _b}] ->
           acc = acc + Distance.calculate(point_1, point_2)
           {acc, []}
@@ -18,13 +21,30 @@ defmodule GeoMeasure.Perimeter do
           {acc, rest}
       end
     end)
-    |> elem(0)
   end
 
   @doc """
   Calculates the perimeter of a Geo struct.
   """
   @doc since: "0.0.1"
+
+  @spec calculate(Geo.LineString.t()) :: float()
+  def calculate(%Geo.LineString{coordinates: coords}) do
+    calculate_perimeter(coords)
+  end
+
+  @spec calculate(Geo.LineStringZ.t()) :: float()
+  def calculate(%Geo.LineStringZ{coordinates: coords}) do
+    calculate_perimeter(coords)
+  end
+
+  @spec calculate(Geo.LineStringZM.t()) :: float()
+  def calculate(%Geo.LineStringZM{coordinates: coords}) do
+    coords
+    |> Utils.remove_m_values()
+    |> calculate_perimeter()
+  end
+
   @spec calculate(Geo.Polygon.t()) :: float()
   def calculate(%Geo.Polygon{coordinates: [coords]}) do
     calculate_perimeter(coords)

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -4,10 +4,9 @@ defmodule GeoMeasure.Perimeter do
   alias GeoMeasure.{Distance, Utils}
 
   @spec calculate_perimeter([{number, number}]) :: float
-  defp calculate_perimeter(coords) when is_list(coords) do
+  defp calculate_perimeter(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn point_1, {acc, remaining} ->
-      IO.inspect({point_1, remaining, acc})
       case remaining do
         [] ->
           acc

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -7,7 +7,7 @@ defmodule GeoMeasure.Utils do
   Checks if neither of the tuple elements is nil.
   """
   @doc since: "0.0.1"
-  @spec tuple_not_nil!(Tuple) :: ArgumentError
+  @spec tuple_not_nil!(tuple) :: ArgumentError
   def tuple_not_nil!(tpl) when is_tuple(tpl) do
     tpl
     |> Tuple.to_list()
@@ -15,6 +15,15 @@ defmodule GeoMeasure.Utils do
       if is_nil(x) do
         raise ArgumentError, message: "Tuple contains nil value: {#{inspect(tpl)}}"
       end
+    end)
+  end
+
+  @spec remove_m_values([{number, number, number} | {number, number, number, number}]) :: [{number, number} | {number, number, number}]
+  def remove_m_values(coords) when is_list(coords) do
+    Enum.map(coords, fn
+      {a, b, _c} -> {a, b}
+      {a, b, c, _d} -> {a, b, c}
+      _ -> raise ArgumentError, message: "Wrong tuple size: {#{inspect(coords)}}"
     end)
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -18,7 +18,9 @@ defmodule GeoMeasure.Utils do
     end)
   end
 
-  @spec remove_m_values([{number, number, number} | {number, number, number, number}]) :: [{number, number} | {number, number, number}]
+  @spec remove_m_values([{number, number, number} | {number, number, number, number}]) :: [
+          {number, number} | {number, number, number}
+        ]
   def remove_m_values(coords) when is_list(coords) do
     Enum.map(coords, fn
       {a, b, _c} -> {a, b}

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GeoMeasure.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/simagyari/geomeasure"
-  @version "1.2.0"
+  @version "1.3.0"
 
   def project do
     [

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -26,6 +26,16 @@ defmodule GeoMeasure.Centroid.Test do
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {2.0, 3.0}}
   end
 
+  test "calculate_linestringz_centroid" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+  end
+
+  test "calculate_linestringzm_centroid" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+  end
+
   test "calculate_polygon_centroid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
@@ -63,6 +73,16 @@ defmodule GeoMeasure.Centroid.Test do
 
   test "calculate_linestring_centroid_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, nil}, {3, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
+
+  test "calculate_linestringz_centroid_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, nil}, {3, 4, 5}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
+
+  test "calculate_linestringzm_centroid_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, nil, 5, 11}]}
     assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
   end
 

--- a/test/geomeasure/extent_test.exs
+++ b/test/geomeasure/extent_test.exs
@@ -11,6 +11,16 @@ defmodule GeoMeasure.Extent.Test do
     assert GeoMeasure.Extent.calculate(geom) == {1, 3, 2, 4}
   end
 
+  test "calculate_linestringz_extent" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]}
+    assert GeoMeasure.Extent.calculate(geom) == {1, 3, 2, 4, 3, 5}
+  end
+
+  test "calculate_linestringzm_extent" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]}
+    assert GeoMeasure.Extent.calculate(geom) == {1, 3, 2, 4, 3, 5}
+  end
+
   test "calculate_polygon_extent" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Extent.calculate(geom) == {0, 2, 0, 2}
@@ -18,6 +28,16 @@ defmodule GeoMeasure.Extent.Test do
 
   test "calculate_linestring_extent_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
+  end
+
+  test "calculate_linestringz_extent_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, nil}, {3, 4, 5}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
+  end
+
+  test "calculate_linestringzm_extent_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, nil, 5, 11}]}
     assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
   end
 

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -122,6 +122,16 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {2.0, 3.0}}
   end
 
+  test "calculate_linestringz_centroid" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+  end
+
+  test "calculate_linestringzm_centroid" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+  end
+
   test "calculate_polygon_centroid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
@@ -159,6 +169,16 @@ defmodule GeoMeasure.Test do
 
   test "calculate_linestring_centroid_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, nil}, {3, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
+  test "calculate_linestringz_centroid_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, nil}, {3, 4, 5}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
+  test "calculate_linestringzm_centroid_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, nil, 5, 11}]}
     assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
   end
 
@@ -297,6 +317,16 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.extent(geom) == {1, 3, 2, 4}
   end
 
+  test "calculate_linestringz_extent" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]}
+    assert GeoMeasure.extent(geom) == {1, 3, 2, 4, 3, 5}
+  end
+
+  test "calculate_linestringzm_extent" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]}
+    assert GeoMeasure.extent(geom) == {1, 3, 2, 4, 3, 5}
+  end
+
   test "calculate_polygon_extent" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.extent(geom) == {0, 2, 0, 2}
@@ -304,6 +334,16 @@ defmodule GeoMeasure.Test do
 
   test "calculate_linestring_extent_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
+  end
+
+  test "calculate_linestringz_extent_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, nil}, {3, 4, 5}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
+  end
+
+  test "calculate_linestringzm_extent_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, nil, 5, 11}]}
     assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
   end
 
@@ -317,14 +357,54 @@ defmodule GeoMeasure.Test do
     assert_raise FunctionClauseError, fn -> GeoMeasure.perimeter(geom) end
   end
 
-  test "calculate_linestring_perimeter" do
-    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
+  test "calculate_pointm_perimeter" do
+    geom = %Geo.PointM{coordinates: {1, 2}}
     assert_raise FunctionClauseError, fn -> GeoMeasure.perimeter(geom) end
+  end
+
+  test "calculate_pointz_perimeter" do
+    geom = %Geo.PointZ{coordinates: {1, 2}}
+    assert_raise FunctionClauseError, fn -> GeoMeasure.perimeter(geom) end
+  end
+
+  test "calculate_pointzm_perimeter" do
+    geom = %Geo.PointZM{coordinates: {1, 2}}
+    assert_raise FunctionClauseError, fn -> GeoMeasure.perimeter(geom) end
+  end
+
+  test "calculate_linestring_length" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {1, 4}]}
+    assert GeoMeasure.length(geom) == 2.0
+  end
+
+  test "calculate_linestringz_length" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, 4, 2}]}
+    assert GeoMeasure.length(geom) == 2.0
+  end
+
+  test "calculate_linestringzm_length" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 2, 10}, {1, 4, 2, 11}]}
+    assert GeoMeasure.length(geom) == 2.0
   end
 
   test "calculate_polygon_perimeter" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.perimeter(geom) == 8.0
+  end
+
+  test "calculate_linestring_length_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, nil}, {1, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.length(geom) end
+  end
+
+  test "calculate_linestringz_length_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, nil, 2}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.length(geom) end
+  end
+
+  test "calculate_linestringzm_length_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{nil, 2, 2, 10}, {1, 4, 2, 11}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.length(geom) end
   end
 
   test "calculate_polygon_perimeter_nil_coord" do

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -6,14 +6,54 @@ defmodule GeoMeasure.Perimeter.Test do
     assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 
-  test "calculate_linestring_perimeter" do
-    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}]}
+  test "calculate_pointm_perimeter" do
+    geom = %Geo.PointM{coordinates: {1, 2}}
     assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_pointz_perimeter" do
+    geom = %Geo.PointZ{coordinates: {1, 2}}
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_pointzm_perimeter" do
+    geom = %Geo.PointZM{coordinates: {1, 2}}
+    assert_raise FunctionClauseError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_linestring_length" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {1, 4}]}
+    assert GeoMeasure.Perimeter.calculate(geom) == 2.0
+  end
+
+  test "calculate_linestringz_length" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, 4, 2}]}
+    assert GeoMeasure.Perimeter.calculate(geom) == 2.0
+  end
+
+  test "calculate_linestringzm_length" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 2, 10}, {1, 4, 2, 11}]}
+    assert GeoMeasure.Perimeter.calculate(geom) == 2.0
   end
 
   test "calculate_polygon_perimeter" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.Perimeter.calculate(geom) == 8.0
+  end
+
+  test "calculate_linestring_length_nil_coord" do
+    geom = %Geo.LineString{coordinates: [{1, nil}, {1, 4}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_linestringz_length_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 2}, {1, nil, 2}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_linestringzm_length_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{nil, 2, 2, 10}, {1, 4, 2, 11}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 
   test "calculate_polygon_perimeter_nil_coord" do


### PR DESCRIPTION
This PR aims to introduce partial support for Geo.LineStringZ and Geo.LineStringZM structs. The reason for the partial support is that Geo has not yet implemented the PolygonZM struct which would be needed for the bounding box calculations of any 3d geometry except points. This PR also fixes a bug with the area calculation and introduces the length function to measure the length of linear structs.