### PR TITLE
feat: transfer srid in calculations that return Geo structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- [Added SRID transfer capability to calculations that return Geo structs](). This involves the `bbox` and `perimeter` functions. Please refer to the [documentation](https://github.com/simagyari/geomeasure/blob/main/README.md) for more information.
+- [Added SRID transfer capability to calculations that return Geo structs](https://github.com/simagyari/geomeasure/pull/22). This involves the `bbox` and `perimeter` functions. Please refer to the [documentation](https://github.com/simagyari/geomeasure/blob/main/README.md) for more information.
 
 ## v1.3.0 - 2025-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.4.0 - 2025-06-22
+
+### Enhancements
+
+- [Added SRID transfer capability to calculations that return Geo structs](). This involves the `bbox` and `perimeter` functions. Please refer to the [documentation](https://github.com/simagyari/geomeasure/blob/main/README.md) for more information.
+
 ## v1.3.0 - 2025-05-24
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ For each geometry, only the properties that have meaning for the given geometry 
 > [!IMPORTANT]
 > All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
 
-_Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
+> [!IMPORTANT]
+> Currently only simple polygons are supported for the area calculations.
 
-_Note_: Currently only simple polygons are supported for the area calculations.
+> [!NOTE]
+> The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
 
-_Note_: If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
+> [!NOTE]
+> If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
 
 ```elixir
 defp deps do

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ iex(1)> GeoMeasure.bbox(%Geo.Point{coordinates: {1, 2}})
 %Geo.Point{coordinates: {1, 2}, srid: nil, properties: %{}}
 
 iex(2)> GeoMeasure.bbox(%Geo.PointM{coordinates: {1, 2, 5}})
-%Geo.Point{coordinates: {1, 2}}
+%Geo.Point{coordinates: {1, 2}, srid: nil, properties: %{}}
 
 iex(3)> GeoMeasure.bbox(%Geo.PointZ{coordinates: {1, 2, 5}})
-%Geo.PointZ{coordinates: {1, 2, 5}}
+%Geo.PointZ{coordinates: {1, 2, 5}, srid: nil, properties: %{}}
 
 iex(4)> GeoMeasure.bbox(%Geo.PointZM{coordinates: {1, 2, 5, 8}})
-%Geo.PointZ{coordinates: {1, 2, 5}}
+%Geo.PointZ{coordinates: {1, 2, 5}, srid: nil, properties: %{}}
 
 iex(5)> GeoMeasure.bbox(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
 %Geo.Polygon{
@@ -109,22 +109,22 @@ iex(1)> GeoMeasure.centroid(%Geo.Point{coordinates: {1, 2}})
 %Geo.Point{coordinates: {1, 2}, srid: nil, properties: %{}}
 
 iex(2)> GeoMeasure.centroid(%Geo.PointM{coordinates: {1, 2, 5}})
-%Geo.Point{coordinates: {1, 2}}
+%Geo.Point{coordinates: {1, 2}, srid: nil, properties: %{}}
 
 iex(3)> GeoMeasure.centroid(%Geo.PointZ{coordinates: {1, 2, 5}})
-%Geo.PointZ{coordinates: {1, 2, 5}}
+%Geo.PointZ{coordinates: {1, 2, 5}, srid: nil, properties: %{}}
 
 iex(4)> GeoMeasure.centroid(%Geo.PointZM{coordinates: 1, 2, 5, 8})
-%Geo.PointZ{coordinates: {1, 2, 5}}
+%Geo.PointZ{coordinates: {1, 2, 5}, srid: nil, properties: %{}}
 
 iex(5)> GeoMeasure.centroid(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
 %Geo.Point{coordinates: {2.0, 3.0}, srid: nil, properties: %{}}
 
 iex(6)> GeoMeasure.centroid(%Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}]})
-%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}, srid: nil, properties: %{}}
 
 iex(7)> GeoMeasure.centroid(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}]})
-%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}}
+%Geo.PointZ{coordinates: {2.0, 3.0, 4.0}, srid: nil, properties: %{}}
 
 iex(8)> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 %Geo.Point{coordinates: {1.0, 1.0}, srid: nil, properties: %{}}

--- a/README.md
+++ b/README.md
@@ -42,17 +42,13 @@ For each geometry, only the properties that have meaning for the given geometry 
 | LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
 | Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ❌    | ✅        |
 
-> [!IMPORTANT]
-> All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
+**IMPORTANT**: All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
 
-> [!IMPORTANT]
-> Currently only simple polygons are supported for the area calculations.
+**IMPORTANT**: Currently only simple polygons are supported for the area calculations.
 
-> [!NOTE]
-> The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
+_Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
 
-> [!NOTE]
-> If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
+_Note_: If you would like to make in-memory calculations to determine the relationship between two Geo structs, please check out [topo](https://github.com/pkinney/topo).
 
 ```elixir
 defp deps do

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ For each geometry, only the properties that have meaning for the given geometry 
 | LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
 | Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ❌    | ✅        |
 
+> [!IMPORTANT]
+> All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
+
 _Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
 
 _Note_: Currently only simple polygons are supported for the area calculations.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ _Note_: If you would like to make in-memory calculations to determine the relati
 ```elixir
 defp deps do
   [
-    {:geomeasure, "~> 1.3.0"}
+    {:geomeasure, "~> 1.4.0"}
   ]
 end
 ```

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -3,8 +3,8 @@ defmodule GeoMeasure.Bbox do
 
   alias GeoMeasure.{Extent, Utils}
 
-  @spec calculate_bbox([{number, number}]) :: Geo.Polygon.t()
-  defp calculate_bbox(coords) do
+  @spec calculate_bbox([{number, number}], number | nil) :: Geo.Polygon.t()
+  defp calculate_bbox(coords, srid) do
     {min_x, max_x, min_y, max_y} = Extent.calculate_extent(coords)
 
     %Geo.Polygon{
@@ -16,7 +16,8 @@ defmodule GeoMeasure.Bbox do
           {max_x, min_y},
           {min_x, min_y}
         ]
-      ]
+      ],
+      srid: srid
     }
   end
 
@@ -31,30 +32,30 @@ defmodule GeoMeasure.Bbox do
   end
 
   @spec calculate(Geo.PointM.t()) :: Geo.Point.t()
-  def calculate(%Geo.PointM{coordinates: {x, y, _}}) do
+  def calculate(%Geo.PointM{coordinates: {x, y, _}, srid: srid}) do
     Utils.tuple_not_nil!({x, y})
-    %Geo.Point{coordinates: {x, y}}
+    %Geo.Point{coordinates: {x, y}, srid: srid}
   end
 
   @spec calculate(Geo.PointZ.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.PointZ{coordinates: coords}) do
+  def calculate(%Geo.PointZ{coordinates: coords, srid: srid}) do
     Utils.tuple_not_nil!(coords)
-    %Geo.PointZ{coordinates: coords}
+    %Geo.PointZ{coordinates: coords, srid: srid}
   end
 
   @spec calculate(Geo.PointZM.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.PointZM{coordinates: {x, y, z, _}}) do
+  def calculate(%Geo.PointZM{coordinates: {x, y, z, _}, srid: srid}) do
     Utils.tuple_not_nil!({x, y, z})
-    %Geo.PointZ{coordinates: {x, y, z}}
+    %Geo.PointZ{coordinates: {x, y, z}, srid: srid}
   end
 
   @spec calculate(Geo.LineString.t()) :: Geo.Polygon.t()
-  def calculate(%Geo.LineString{coordinates: coords}) do
-    calculate_bbox(coords)
+  def calculate(%Geo.LineString{coordinates: coords, srid: srid}) do
+    calculate_bbox(coords, srid)
   end
 
   @spec calculate(Geo.Polygon.t()) :: Geo.Polygon.t()
-  def calculate(%Geo.Polygon{coordinates: [coords]}) do
-    calculate_bbox(coords)
+  def calculate(%Geo.Polygon{coordinates: [coords], srid: srid}) do
+    calculate_bbox(coords, srid)
   end
 end

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -4,8 +4,8 @@ defmodule GeoMeasure.Centroid do
   alias Geo
   alias GeoMeasure.Utils
 
-  @spec calculate_centroid([{number, number}]) :: Geo.Point.t()
-  defp calculate_centroid(coords) do
+  @spec calculate_centroid([{number, number}], number) :: Geo.Point.t()
+  defp calculate_centroid(coords, srid) do
     {sum_x, sum_y} =
       Enum.reduce(coords, {0, 0}, fn tpl, acc ->
         Utils.tuple_not_nil!(tpl)
@@ -14,11 +14,11 @@ defmodule GeoMeasure.Centroid do
 
     mean_x = sum_x / length(coords)
     mean_y = sum_y / length(coords)
-    %Geo.Point{coordinates: {mean_x, mean_y}}
+    %Geo.Point{coordinates: {mean_x, mean_y}, srid: srid}
   end
 
-  @spec calculate_centroid_3d([{number, number, number}]) :: Geo.PointZ.t()
-  defp calculate_centroid_3d(coords) do
+  @spec calculate_centroid_3d([{number, number, number}], number) :: Geo.PointZ.t()
+  defp calculate_centroid_3d(coords, srid) do
     {sum_x, sum_y, sum_z} =
       Enum.reduce(coords, {0, 0, 0}, fn tpl, acc ->
         Utils.tuple_not_nil!(tpl)
@@ -28,7 +28,7 @@ defmodule GeoMeasure.Centroid do
     mean_x = sum_x / length(coords)
     mean_y = sum_y / length(coords)
     mean_z = sum_z / length(coords)
-    %Geo.PointZ{coordinates: {mean_x, mean_y, mean_z}}
+    %Geo.PointZ{coordinates: {mean_x, mean_y, mean_z}, srid: srid}
   end
 
   @spec sum_coordinates({number, number}, {number, number}) :: {number, number}
@@ -49,42 +49,42 @@ defmodule GeoMeasure.Centroid do
   end
 
   @spec calculate(Geo.PointM.t()) :: Geo.Point.t()
-  def calculate(%Geo.PointM{coordinates: {x, y, _z}}) do
+  def calculate(%Geo.PointM{coordinates: {x, y, _z}, srid: srid}) do
     Utils.tuple_not_nil!({x, y})
-    %Geo.Point{coordinates: {x, y}}
+    %Geo.Point{coordinates: {x, y}, srid: srid}
   end
 
   @spec calculate(Geo.PointZ.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.PointZ{coordinates: coords}) do
+  def calculate(%Geo.PointZ{coordinates: coords, srid: srid}) do
     Utils.tuple_not_nil!(coords)
-    %Geo.PointZ{coordinates: coords}
+    %Geo.PointZ{coordinates: coords, srid: srid}
   end
 
   @spec calculate(Geo.PointZM.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.PointZM{coordinates: {x, y, z, _}}) do
+  def calculate(%Geo.PointZM{coordinates: {x, y, z, _}, srid: srid}) do
     Utils.tuple_not_nil!({x, y, z})
-    %Geo.PointZ{coordinates: {x, y, z}}
+    %Geo.PointZ{coordinates: {x, y, z}, srid: srid}
   end
 
   @spec calculate(Geo.LineString.t()) :: Geo.Point.t()
-  def calculate(%Geo.LineString{coordinates: coords}) do
-    calculate_centroid(coords)
+  def calculate(%Geo.LineString{coordinates: coords, srid: srid}) do
+    calculate_centroid(coords, srid)
   end
 
   @spec calculate(Geo.LineStringZ.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.LineStringZ{coordinates: coords}) do
-    calculate_centroid_3d(coords)
+  def calculate(%Geo.LineStringZ{coordinates: coords, srid: srid}) do
+    calculate_centroid_3d(coords, srid)
   end
 
   @spec calculate(Geo.LineStringZM.t()) :: Geo.PointZ.t()
-  def calculate(%Geo.LineStringZM{coordinates: coords}) do
+  def calculate(%Geo.LineStringZM{coordinates: coords, srid: srid}) do
     coords
     |> Utils.remove_m_values()
-    |> calculate_centroid_3d()
+    |> calculate_centroid_3d(srid)
   end
 
   @spec calculate(Geo.Polygon.t()) :: Get.Point.t()
-  def calculate(%Geo.Polygon{coordinates: [coords]}) do
-    calculate_centroid(tl(coords))
+  def calculate(%Geo.Polygon{coordinates: [coords], srid: srid}) do
+    calculate_centroid(tl(coords), srid)
   end
 end

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -4,7 +4,7 @@ defmodule GeoMeasure.Centroid do
   alias Geo
   alias GeoMeasure.Utils
 
-  @spec calculate_centroid([{number, number}], number) :: Geo.Point.t()
+  @spec calculate_centroid([{number, number}], number | nil) :: Geo.Point.t()
   defp calculate_centroid(coords, srid) do
     {sum_x, sum_y} =
       Enum.reduce(coords, {0, 0}, fn tpl, acc ->
@@ -17,7 +17,7 @@ defmodule GeoMeasure.Centroid do
     %Geo.Point{coordinates: {mean_x, mean_y}, srid: srid}
   end
 
-  @spec calculate_centroid_3d([{number, number, number}], number) :: Geo.PointZ.t()
+  @spec calculate_centroid_3d([{number, number, number}], number | nil) :: Geo.PointZ.t()
   defp calculate_centroid_3d(coords, srid) do
     {sum_x, sum_y, sum_z} =
       Enum.reduce(coords, {0, 0, 0}, fn tpl, acc ->

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GeoMeasure.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/simagyari/geomeasure"
-  @version "1.3.0"
+  @version "1.4.0"
 
   def project do
     [

--- a/test/geomeasure/bbox_test.exs
+++ b/test/geomeasure/bbox_test.exs
@@ -76,4 +76,42 @@ defmodule GeoMeasure.Bbox.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, nil}, {2, 0}, {0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
   end
+
+  test "calculate_point_bbox_with_srid" do
+    geom = %Geo.Point{coordinates: {1, 2}, srid: 27700}
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Point{coordinates: {1, 2}, srid: 27700}
+  end
+
+  test "calculate_pointm_bbox_with_srid" do
+    geom = %Geo.PointM{coordinates: {1, 2, 5}, srid: 27700}
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Point{coordinates: {1, 2}, srid: 27700}
+  end
+
+  test "calculate_pointz_bbox_with_srid" do
+    geom = %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+  end
+
+  test "calculate_pointzm_bbox_with_srid" do
+    geom = %Geo.PointZM{coordinates: {1, 2, 5, 8}, srid: 27700}
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+  end
+
+  test "calculate_linestring_bbox_with_srid" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}], srid: 27700}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+             coordinates: [[{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}]],
+             srid: 27700
+           }
+  end
+
+  test "calculate_polygon_bbox_with_srid" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 27700}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             srid: 27700
+           }
+  end
 end

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -90,4 +90,52 @@ defmodule GeoMeasure.Centroid.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
   end
+
+  test "calculate_point_centroid_with_srid" do
+    geom = %Geo.Point{coordinates: {1, 2}, srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
+  end
+
+  test "calculate_pointm_centroid_with_srid" do
+    geom = %Geo.PointM{coordinates: {1, 2, 3}, srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
+  end
+
+  test "calculate_pointz_centroid_with_srid" do
+    geom = %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+  end
+
+  test "calculate_pointzm_centroid_with_srid" do
+    geom = %Geo.PointZM{coordinates: {1, 2, 5, 8}, srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+  end
+
+  test "calculate_linestring_centroid_with_srid" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}], srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {2.0, 3.0}, srid: 23700}
+  end
+
+  test "calculate_linestringz_centroid_with_srid" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}], srid: 23700}
+
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{
+             coordinates: {2.0, 3.0, 4.0},
+             srid: 23700
+           }
+  end
+
+  test "calculate_linestringzm_centroid_with_srid" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}], srid: 23700}
+
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{
+             coordinates: {2.0, 3.0, 4.0},
+             srid: 23700
+           }
+  end
+
+  test "calculate_polygon_centroid_with_srid" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}, srid: 23700}
+  end
 end

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -97,6 +97,44 @@ defmodule GeoMeasure.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
   end
 
+  test "calculate_point_bbox_with_srid" do
+    geom = %Geo.Point{coordinates: {1, 2}, srid: 27700}
+    assert GeoMeasure.bbox(geom) == %Geo.Point{coordinates: {1, 2}, srid: 27700}
+  end
+
+  test "calculate_pointm_bbox_with_srid" do
+    geom = %Geo.PointM{coordinates: {1, 2, 5}, srid: 27700}
+    assert GeoMeasure.bbox(geom) == %Geo.Point{coordinates: {1, 2}, srid: 27700}
+  end
+
+  test "calculate_pointz_bbox_with_srid" do
+    geom = %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+    assert GeoMeasure.bbox(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+  end
+
+  test "calculate_pointzm_bbox_with_srid" do
+    geom = %Geo.PointZM{coordinates: {1, 2, 5, 8}, srid: 27700}
+    assert GeoMeasure.bbox(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 27700}
+  end
+
+  test "calculate_linestring_bbox_with_srid" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}], srid: 27700}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+             coordinates: [[{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}]],
+             srid: 27700
+           }
+  end
+
+  test "calculate_polygon_bbox_with_srid" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 27700}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             srid: 27700
+           }
+  end
+
   test "calculate_point_centroid" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1, 2}}
@@ -185,6 +223,54 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_centroid_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
+  test "calculate_point_centroid_with_srid" do
+    geom = %Geo.Point{coordinates: {1, 2}, srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
+  end
+
+  test "calculate_pointm_centroid_with_srid" do
+    geom = %Geo.PointM{coordinates: {1, 2, 3}, srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
+  end
+
+  test "calculate_pointz_centroid_with_srid" do
+    geom = %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+  end
+
+  test "calculate_pointzm_centroid_with_srid" do
+    geom = %Geo.PointZM{coordinates: {1, 2, 5, 8}, srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {1, 2, 5}, srid: 23700}
+  end
+
+  test "calculate_linestring_centroid_with_srid" do
+    geom = %Geo.LineString{coordinates: [{1, 2}, {3, 4}], srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {2.0, 3.0}, srid: 23700}
+  end
+
+  test "calculate_linestringz_centroid_with_srid" do
+    geom = %Geo.LineStringZ{coordinates: [{1, 2, 3}, {3, 4, 5}], srid: 23700}
+
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{
+             coordinates: {2.0, 3.0, 4.0},
+             srid: 23700
+           }
+  end
+
+  test "calculate_linestringzm_centroid_with_srid" do
+    geom = %Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 5, 11}], srid: 23700}
+
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{
+             coordinates: {2.0, 3.0, 4.0},
+             srid: 23700
+           }
+  end
+
+  test "calculate_polygon_centroid_with_srid" do
+    geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}, srid: 23700}
   end
 
   test "calculate_distance_x_direction" do


### PR DESCRIPTION
This PR enables the transfer of SRIDs in calculations that return Geo structs. These are, as of now, bbox and centroid.