### PR TITLE
feat: add support for polygons with holes in area and perimeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For each geometry, only the properties that have meaning for the given geometry 
 
 **IMPORTANT**: All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
 
-**IMPORTANT**: Currently only simple polygons are supported for the area calculations.
+**IMPORTANT**: Currently only coplanar polygons are supported for the area calculations.
 
 _Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
 
@@ -66,6 +66,14 @@ While each function can be called through their module, such as `GeoMeasure.Area
 ```elixir
 iex(1)> GeoMeasure.area(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 4.0
+
+iex(2)> GeoMeasure.area(%Geo.Polygon{
+    coordinates: [
+      [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+      [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+    ]
+  })
+8.0
 ```
 
 ### Bounding Box
@@ -187,6 +195,14 @@ iex(3)> GeoMeasure.length(%Geo.LineStringZM{coordinates: [{1, 2, 2, 10}, {1, 4, 
 
 iex(4)> GeoMeasure.perimeter(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 8.0
+
+iex(5)> GeoMeasure.perimeter(%Geo.Polygon{
+    coordinates: [
+      [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+      [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+    ]
+  })
+16.0
 ```
 
 ## Copyright and License

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -29,7 +29,17 @@ defmodule GeoMeasure.Area do
   """
   @doc since: "0.0.1"
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: [coords]}) do
-    calculate_area(coords)
+  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) == 1 do
+    calculate_area(hd(coord_list))
+  end
+
+  @spec calculate(Geo.Polygon.t()) :: float
+  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) > 1 do
+    [outer_ring | rest] = coord_list
+    outer_area = calculate_area(outer_ring)
+    inner_area = Enum.reduce(rest, 0, fn coords, acc ->
+      acc + calculate_area(coords)
+    end)
+    outer_area - inner_area
   end
 end

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -37,9 +37,12 @@ defmodule GeoMeasure.Area do
   def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) > 1 do
     [outer_ring | rest] = coord_list
     outer_area = calculate_area(outer_ring)
-    inner_area = Enum.reduce(rest, 0, fn coords, acc ->
-      acc + calculate_area(coords)
-    end)
+
+    inner_area =
+      Enum.reduce(rest, 0, fn coords, acc ->
+        acc + calculate_area(coords)
+      end)
+
     outer_area - inner_area
   end
 end

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -45,7 +45,12 @@ defmodule GeoMeasure.Perimeter do
   end
 
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: [coords]}) do
-    calculate_perimeter(coords)
+  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) == 1 do
+    calculate_perimeter(hd(coord_list))
+  end
+
+  @spec calculate(Geo.Polygon.t()) :: float
+  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) > 1 do
+    Enum.reduce(coord_list, 0, fn coords, acc -> acc + calculate_perimeter(coords) end)
   end
 end

--- a/test/geomeasure/area_test.exs
+++ b/test/geomeasure/area_test.exs
@@ -20,4 +20,15 @@ defmodule GeoMeasure.Area.Test do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Area.calculate(geom) end
   end
+
+  test "calculate_polygon_area_hole" do
+    geom = %Geo.Polygon{
+      coordinates: [
+        [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+        [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+      ]
+    }
+
+    assert GeoMeasure.Area.calculate(geom) == 8.0
+  end
 end

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -21,6 +21,17 @@ defmodule GeoMeasure.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.area(geom) end
   end
 
+  test "calculate_polygon_area_hole" do
+    geom = %Geo.Polygon{
+      coordinates: [
+        [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+        [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+      ]
+    }
+
+    assert GeoMeasure.area(geom) == 8.0
+  end
+
   test "calculate_point_bbox" do
     geom = %Geo.Point{coordinates: {1, 2}}
     assert GeoMeasure.bbox(geom) == %Geo.Point{coordinates: {1, 2}}
@@ -476,6 +487,17 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_perimeter" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.perimeter(geom) == 8.0
+  end
+
+  test "calculate_polygon_perimeter_hole" do
+    geom = %Geo.Polygon{
+      coordinates: [
+        [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+        [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+      ]
+    }
+
+    assert GeoMeasure.perimeter(geom) == 16.0
   end
 
   test "calculate_linestring_length_nil_coord" do

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -41,6 +41,17 @@ defmodule GeoMeasure.Perimeter.Test do
     assert GeoMeasure.Perimeter.calculate(geom) == 8.0
   end
 
+  test "calculate_polygon_perimeter_hole" do
+    geom = %Geo.Polygon{
+      coordinates: [
+        [{0, 0}, {0, 3}, {3, 3}, {3, 0}, {0, 0}],
+        [{1, 1}, {1, 2}, {2, 2}, {2, 1}, {1, 1}]
+      ]
+    }
+
+    assert GeoMeasure.Perimeter.calculate(geom) == 16.0
+  end
+
   test "calculate_linestring_length_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, nil}, {1, 4}]}
     assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end


### PR DESCRIPTION
This PR aims to add support for polygons with holes in area and perimeter calculations. The areas of holes get subtracted from the area of the outer ring, while the perimeters of holes get added to the perimeter of the outer ring.