### PR TITLE
feat: add support for LineStringZ, LineStringZM, and PolygonZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently, the following properties can be calculated for the supported [Geo](ht
 - Extent
 - Length/Perimeter
 
-For each geometry, only the properties that have meaning for the given geometry are implemented. This results in the following implementation table, where ✅ means supported, and ❌ means unsupported property, while 🔶 means incomplete or in progress support for a property:
+For each geometry, only the properties that have meaning for the given geometry are implemented. This results in the following implementation table, where ✅ means supported, and ❌ means unsupported property, 🎯 means planned, while 🔶 means incomplete or in progress support for a property:
 
 | Geometry     | Area | Bounding box | Centroid | Distance | Extent | Length | Perimeter |
 | ----------   | :--: | :----------: | :------: | :------: | :----: | :----: | :-------: |
@@ -38,13 +38,14 @@ For each geometry, only the properties that have meaning for the given geometry 
 | PointZ       | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
 | PointZM      | ❌   | ✅          | ✅       | ✅      | ❌     | ❌    | ❌        |
 | LineString   | ❌   | ✅          | ✅       | ❌      | ✅     | ✅    | ❌        |
-| LineStringZ  | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
-| LineStringZM | ❌   | 🔶          | ✅       | ❌      | ✅     | ✅    | ❌        |
+| LineStringZ  | ❌   | ✅          | ✅       | ❌      | ✅     | ✅    | ❌        |
+| LineStringZM | ❌   | ✅          | ✅       | ❌      | ✅     | ✅    | ❌        |
 | Polygon      | ✅   | ✅          | ✅       | ❌      | ✅     | ❌    | ✅        |
+| PolygonZ     | 🎯   | ✅          | ✅       | ❌      | ✅     | ❌    | ✅        |
 
 **IMPORTANT**: All computations that return Geo structs transfer the SRID of the input struct to the output struct. Only projected coordinate systems are supported as the algorithms implemented here do not take curved surfaces and angular units into account, which would be necessary for the handling of geographic coordinate systems.
 
-**IMPORTANT**: Currently only coplanar polygons are supported for the area calculations.
+**IMPORTANT**: Both area and perimeter can handle polygons with holes now. Area is missing PolygonZ support.
 
 _Note_: The Length/Perimeter depends on the type of geometry. Length is supported for lines, Perimeter is for Polygons. Under the hood, they use the same calculation.
 
@@ -98,11 +99,32 @@ iex(5)> GeoMeasure.bbox(%Geo.LineString{coordinates: [{1, 2}, {3, 4}]})
   properties: %{}
 }
 
-iex(6)> GeoMeasure.bbox(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
+iex(6)> GeoMeasure.bbox(%Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}]})
+%Geo.Polygon{
+  coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+  srid: nil,
+  properties: %{max_z: 1, min_z: 0}
+}
+
+iex(7)> GeoMeasure.bbox(%Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}]})
+%Geo.Polygon{
+  coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+  srid: nil,
+  properties: %{max_z: 1, min_z: 0}
+}
+
+iex(8)> GeoMeasure.bbox(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 %Geo.Polygon{
   coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
   srid: nil,
   properties: %{}
+}
+
+iex(9)> GeoMeasure.bbox(%Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]})
+%Geo.Polygon{
+  coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+  srid: nil,
+  properties: %{max_z: 2, min_z: 0}
 }
 ```
 
@@ -132,6 +154,9 @@ iex(7)> GeoMeasure.centroid(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4
 
 iex(8)> GeoMeasure.centroid(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 %Geo.Point{coordinates: {1.0, 1.0}, srid: nil, properties: %{}}
+
+iex(9)> GeoMeasure.centroid(%Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]})
+%Geo.PointZ{coordinates: {1.0, 1.0, 1.0}, srid: nil, properties: %{}}
 ```
 
 ### Distance
@@ -179,6 +204,9 @@ iex(3)> GeoMeasure.extent(%Geo.LineStringZM{coordinates: [{1, 2, 3, 10}, {3, 4, 
 
 iex(4)> GeoMeasure.extent(%Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]})
 {0, 2, 0, 2}
+
+iex(5)> GeoMeasure.extent(%Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]})
+{0, 2, 0, 2, 0, 2}
 ```
 
 ### Perimeter/Length
@@ -203,6 +231,17 @@ iex(5)> GeoMeasure.perimeter(%Geo.Polygon{
     ]
   })
 16.0
+
+iex(6)> GeoMeasure.perimeter(%Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]})
+8.94427190999916
+
+iex(7)> GeoMeasure.perimeter(%Geo.PolygonZ{
+    coordinates: [
+      [{0, 0, 0}, {0, 3, 1}, {3, 3, 2}, {3, 0, 1}, {0, 0, 0}],
+      [{1, 1, 0.66}, {1, 2, 1}, {2, 2, 1.33}, {2, 1, 1}, {1, 1, 0.66}]
+    ]
+  })
+16.8676364068953
 ```
 
 ## Copyright and License

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Currently, this project supports only the following geometries:
 - PointZ
 - PointZM
 - LineString
-- LineStringZ (partial support)
-- LineStringZM (partial support)
+- LineStringZ
+- LineStringZM
 - Polygon
+- PolygonZ
 
 Currently, the following properties can be calculated for the supported [Geo](https://github.com/felt/geo/tree/master) structs:
 

--- a/lib/geomeasure/area.ex
+++ b/lib/geomeasure/area.ex
@@ -29,18 +29,20 @@ defmodule GeoMeasure.Area do
   """
   @doc since: "0.0.1"
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) == 1 do
-    calculate_area(hd(coord_list))
+  def calculate(%Geo.Polygon{coordinates: coords}) when length(coords) == 1 do
+    coords
+    |> hd()
+    |> calculate_area()
   end
 
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) > 1 do
-    [outer_ring | rest] = coord_list
+  def calculate(%Geo.Polygon{coordinates: coords}) when length(coords) > 1 do
+    [outer_ring | rest] = coords
     outer_area = calculate_area(outer_ring)
 
     inner_area =
-      Enum.reduce(rest, 0, fn coords, acc ->
-        acc + calculate_area(coords)
+      Enum.reduce(rest, 0, fn coord_list, acc ->
+        acc + calculate_area(coord_list)
       end)
 
     outer_area - inner_area

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -80,13 +80,24 @@ defmodule GeoMeasure.Bbox do
 
   @spec calculate(Geo.LineStringZM.t()) :: Geo.Polygon.t()
   def calculate(%Geo.LineStringZM{coordinates: coords, srid: srid}) do
-    calculate_bbox_3d(coords, srid)
+    coords
+    |> Utils.remove_m_values()
+    |> calculate_bbox_3d(srid)
   end
 
   @spec calculate(Geo.Polygon.t()) :: Geo.Polygon.t()
-  def calculate(%Geo.Polygon{coordinates: [coords], srid: srid}) do
+  def calculate(%Geo.Polygon{coordinates: coords, srid: srid}) do
     coords
-    |> Utils.remove_m_values()
+    |> hd()
+    |> tl()
     |> calculate_bbox(srid)
+  end
+
+  @spec calculate(Geo.PolygonZ.t()) :: Geo.Polygon.t()
+  def calculate(%Geo.PolygonZ{coordinates: coords, srid: srid}) do
+    coords
+    |> hd()
+    |> tl()
+    |> calculate_bbox_3d(srid)
   end
 end

--- a/lib/geomeasure/bbox.ex
+++ b/lib/geomeasure/bbox.ex
@@ -21,6 +21,25 @@ defmodule GeoMeasure.Bbox do
     }
   end
 
+  @spec calculate_bbox_3d([{number, number, number}], number | nil) :: Geo.Polygon.t()
+  defp calculate_bbox_3d(coords, srid) do
+    {min_x, max_x, min_y, max_y, min_z, max_z} = Extent.calculate_extent_3d(coords)
+
+    %Geo.Polygon{
+      coordinates: [
+        [
+          {min_x, min_y},
+          {min_x, max_y},
+          {max_x, max_y},
+          {max_x, min_y},
+          {min_x, min_y}
+        ]
+      ],
+      srid: srid,
+      properties: %{min_z: min_z, max_z: max_z}
+    }
+  end
+
   @doc """
   Calculates the bounding box of a Geo struct.
   """
@@ -54,8 +73,20 @@ defmodule GeoMeasure.Bbox do
     calculate_bbox(coords, srid)
   end
 
+  @spec calculate(Geo.LineStringZ.t()) :: Geo.Polygon.t()
+  def calculate(%Geo.LineStringZ{coordinates: coords, srid: srid}) do
+    calculate_bbox_3d(coords, srid)
+  end
+
+  @spec calculate(Geo.LineStringZM.t()) :: Geo.Polygon.t()
+  def calculate(%Geo.LineStringZM{coordinates: coords, srid: srid}) do
+    calculate_bbox_3d(coords, srid)
+  end
+
   @spec calculate(Geo.Polygon.t()) :: Geo.Polygon.t()
   def calculate(%Geo.Polygon{coordinates: [coords], srid: srid}) do
-    calculate_bbox(coords, srid)
+    coords
+    |> Utils.remove_m_values()
+    |> calculate_bbox(srid)
   end
 end

--- a/lib/geomeasure/centroid.ex
+++ b/lib/geomeasure/centroid.ex
@@ -83,8 +83,19 @@ defmodule GeoMeasure.Centroid do
     |> calculate_centroid_3d(srid)
   end
 
-  @spec calculate(Geo.Polygon.t()) :: Get.Point.t()
-  def calculate(%Geo.Polygon{coordinates: [coords], srid: srid}) do
-    calculate_centroid(tl(coords), srid)
+  @spec calculate(Geo.Polygon.t()) :: Geo.Point.t()
+  def calculate(%Geo.Polygon{coordinates: coords, srid: srid}) do
+    coords
+    |> hd()
+    |> tl()
+    |> calculate_centroid(srid)
+  end
+
+  @spec calculate(Geo.PolygonZ.t()) :: Geo.PointZ.t()
+  def calculate(%Geo.PolygonZ{coordinates: coords, srid: srid}) do
+    coords
+    |> hd()
+    |> tl()
+    |> calculate_centroid_3d(srid)
   end
 end

--- a/lib/geomeasure/extent.ex
+++ b/lib/geomeasure/extent.ex
@@ -71,7 +71,18 @@ defmodule GeoMeasure.Extent do
   end
 
   @spec calculate(Geo.Polygon.t()) :: {number, number, number, number}
-  def calculate(%Geo.Polygon{coordinates: [coords]}) do
-    calculate_extent(tl(coords))
+  def calculate(%Geo.Polygon{coordinates: coords}) do
+    coords
+    |> hd()
+    |> tl()
+    |> calculate_extent()
+  end
+
+  @spec calculate(Geo.PolygonZ.t()) :: {number, number, number, number, number, number}
+  def calculate(%Geo.PolygonZ{coordinates: coords}) do
+    coords
+    |> hd()
+    |> tl()
+    |> calculate_extent_3d()
   end
 end

--- a/lib/geomeasure/perimeter.ex
+++ b/lib/geomeasure/perimeter.ex
@@ -3,7 +3,7 @@ defmodule GeoMeasure.Perimeter do
 
   alias GeoMeasure.{Distance, Utils}
 
-  @spec calculate_perimeter([{number, number}]) :: float
+  @spec calculate_perimeter([{number, number}] | [{number, number, number}]) :: float
   defp calculate_perimeter(coords) do
     coords
     |> Enum.reduce({0, tl(coords)}, fn point_1, {acc, remaining} ->
@@ -11,7 +11,7 @@ defmodule GeoMeasure.Perimeter do
         [] ->
           acc
 
-        [point_2 = {_a, _b}] ->
+        [point_2] when is_tuple(point_2) ->
           acc = acc + Distance.calculate(point_1, point_2)
           {acc, []}
 
@@ -45,12 +45,26 @@ defmodule GeoMeasure.Perimeter do
   end
 
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) == 1 do
-    calculate_perimeter(hd(coord_list))
+  def calculate(%Geo.Polygon{coordinates: coords}) when length(coords) == 1 do
+    coords
+    |> hd()
+    |> calculate_perimeter()
   end
 
   @spec calculate(Geo.Polygon.t()) :: float
-  def calculate(%Geo.Polygon{coordinates: coord_list}) when length(coord_list) > 1 do
-    Enum.reduce(coord_list, 0, fn coords, acc -> acc + calculate_perimeter(coords) end)
+  def calculate(%Geo.Polygon{coordinates: coords}) when length(coords) > 1 do
+    Enum.reduce(coords, 0, fn coord_list, acc -> acc + calculate_perimeter(coord_list) end)
+  end
+
+  @spec calculate(Geo.PolygonZ.t()) :: float
+  def calculate(%Geo.PolygonZ{coordinates: coords}) when length(coords) == 1 do
+    coords
+    |> hd()
+    |> calculate_perimeter()
+  end
+
+  @spec calculate(Geo.PolygonZ.t()) :: float
+  def calculate(%Geo.PolygonZ{coordinates: coords}) when length(coords) > 1 do
+    Enum.reduce(coords, 0, fn coord_list, acc -> acc + calculate_perimeter(coord_list) end)
   end
 end

--- a/test/geomeasure/bbox_test.exs
+++ b/test/geomeasure/bbox_test.exs
@@ -33,18 +33,18 @@ defmodule GeoMeasure.Bbox.Test do
     geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}]}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_linestringzm_bbox" do
     geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}]}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_polygon_bbox" do
@@ -152,20 +152,20 @@ defmodule GeoMeasure.Bbox.Test do
     geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}], srid: 23700}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      srid: 23700,
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_linestringzm_bbox_with_srid" do
     geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}], srid: 23700}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      srid: 23700,
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_polygon_bbox_with_srid" do
@@ -178,7 +178,10 @@ defmodule GeoMeasure.Bbox.Test do
   end
 
   test "calculate_polygonz_bbox_with_srid" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]],
+      srid: 23700
+    }
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],

--- a/test/geomeasure/bbox_test.exs
+++ b/test/geomeasure/bbox_test.exs
@@ -29,11 +29,38 @@ defmodule GeoMeasure.Bbox.Test do
            }
   end
 
+  test "calculate_linestringz_bbox" do
+    geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}]}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
+  test "calculate_linestringzm_bbox" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}]}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
   test "calculate_polygon_bbox" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]
+           }
+  end
+
+  test "calculate_polygonz_bbox" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 2}
            }
   end
 
@@ -72,8 +99,23 @@ defmodule GeoMeasure.Bbox.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
   end
 
+  test "calculate_linestringz_bbox_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{0, nil, 0}, {1, 1, 1}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
+
+  test "calculate_linestringzm_bbox_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, nil, 1, 3}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
+
   test "calculate_polygon_bbox_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
+  end
+
+  test "calculate_polygonz_bbox_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Bbox.calculate(geom) end
   end
 
@@ -106,12 +148,42 @@ defmodule GeoMeasure.Bbox.Test do
            }
   end
 
+  test "calculate_linestringz_bbox_with_srid" do
+    geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}], srid: 23700}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      srid: 23700,
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
+  test "calculate_linestringzm_bbox_with_srid" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}], srid: 23700}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      srid: 23700,
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
   test "calculate_polygon_bbox_with_srid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 27700}
 
     assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
              srid: 27700
+           }
+  end
+
+  test "calculate_polygonz_bbox_with_srid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+
+    assert GeoMeasure.Bbox.calculate(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 2}
            }
   end
 end

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -41,6 +41,11 @@ defmodule GeoMeasure.Centroid.Test do
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
   end
 
+  test "calculate_polygonz_centroid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}}
+  end
+
   test "calculate_point_centroid_nil_coord" do
     geom = %Geo.Point{coordinates: {nil, 2}}
     assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
@@ -91,6 +96,11 @@ defmodule GeoMeasure.Centroid.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
   end
 
+  test "calculate_polygonz_centroid_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Centroid.calculate(geom) end
+  end
+
   test "calculate_point_centroid_with_srid" do
     geom = %Geo.Point{coordinates: {1, 2}, srid: 23700}
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
@@ -137,5 +147,10 @@ defmodule GeoMeasure.Centroid.Test do
   test "calculate_polygon_centroid_with_srid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 23700}
     assert GeoMeasure.Centroid.calculate(geom) == %Geo.Point{coordinates: {1.0, 1.0}, srid: 23700}
+  end
+
+  test "calculate_polygonz_centroid_with_srid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}, srid: 23700}
   end
 end

--- a/test/geomeasure/centroid_test.exs
+++ b/test/geomeasure/centroid_test.exs
@@ -150,7 +150,14 @@ defmodule GeoMeasure.Centroid.Test do
   end
 
   test "calculate_polygonz_centroid_with_srid" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
-    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}, srid: 23700}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]],
+      srid: 23700
+    }
+
+    assert GeoMeasure.Centroid.calculate(geom) == %Geo.PointZ{
+             coordinates: {1.0, 1.0, 1.0},
+             srid: 23700
+           }
   end
 end

--- a/test/geomeasure/extent_test.exs
+++ b/test/geomeasure/extent_test.exs
@@ -26,6 +26,11 @@ defmodule GeoMeasure.Extent.Test do
     assert GeoMeasure.Extent.calculate(geom) == {0, 2, 0, 2}
   end
 
+  test "calculate_polygonz_extent" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.Extent.calculate(geom) == {0, 2, 0, 2, 0, 2}
+  end
+
   test "calculate_linestring_extent_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
     assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
@@ -43,6 +48,11 @@ defmodule GeoMeasure.Extent.Test do
 
   test "calculate_polygon_extent_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
+  end
+
+  test "calculate_polygonz_extent_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Extent.calculate(geom) end
   end
 end

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -64,18 +64,18 @@ defmodule GeoMeasure.Test do
     geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}]}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_linestringzm_bbox" do
     geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}]}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_polygon_bbox" do
@@ -183,20 +183,20 @@ defmodule GeoMeasure.Test do
     geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}], srid: 23700}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      srid: 23700,
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_linestringzm_bbox_with_srid" do
     geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}], srid: 23700}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
-      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
-      srid: 23700,
-      properties: %{min_z: 0, max_z: 1}
-    }
+             coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 1}
+           }
   end
 
   test "calculate_polygon_bbox_with_srid" do
@@ -209,7 +209,10 @@ defmodule GeoMeasure.Test do
   end
 
   test "calculate_polygonz_bbox_with_srid" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]],
+      srid: 23700
+    }
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
@@ -367,7 +370,11 @@ defmodule GeoMeasure.Test do
   end
 
   test "calculate_polygonz_centroid_with_srid" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]],
+      srid: 23700
+    }
+
     assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}, srid: 23700}
   end
 
@@ -634,7 +641,10 @@ defmodule GeoMeasure.Test do
   end
 
   test "calculate_polygonz_perimeter_nil_coord" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]
+    }
+
     assert_raise ArgumentError, fn -> GeoMeasure.perimeter(geom) end
   end
 end

--- a/test/geomeasure/geomeasure_test.exs
+++ b/test/geomeasure/geomeasure_test.exs
@@ -60,11 +60,38 @@ defmodule GeoMeasure.Test do
            }
   end
 
+  test "calculate_linestringz_bbox" do
+    geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}]}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
+  test "calculate_linestringzm_bbox" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}]}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
   test "calculate_polygon_bbox" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]
+           }
+  end
+
+  test "calculate_polygonz_bbox" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             properties: %{min_z: 0, max_z: 2}
            }
   end
 
@@ -103,8 +130,23 @@ defmodule GeoMeasure.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
   end
 
+  test "calculate_linestringz_bbox_nil_coord" do
+    geom = %Geo.LineStringZ{coordinates: [{0, nil, 0}, {1, 1, 1}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
+  test "calculate_linestringzm_bbox_nil_coord" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, nil, 1, 3}]}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
   test "calculate_polygon_bbox_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
+  end
+
+  test "calculate_polygonz_bbox_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.bbox(geom) end
   end
 
@@ -137,12 +179,42 @@ defmodule GeoMeasure.Test do
            }
   end
 
+  test "calculate_linestringz_bbox_with_srid" do
+    geom = %Geo.LineStringZ{coordinates: [{0, 0, 0}, {1, 1, 1}], srid: 23700}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      srid: 23700,
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
+  test "calculate_linestringzm_bbox_with_srid" do
+    geom = %Geo.LineStringZM{coordinates: [{0, 0, 0, 2}, {1, 1, 1, 3}], srid: 23700}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+      coordinates: [[{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}]],
+      srid: 23700,
+      properties: %{min_z: 0, max_z: 1}
+    }
+  end
+
   test "calculate_polygon_bbox_with_srid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 27700}
 
     assert GeoMeasure.bbox(geom) == %Geo.Polygon{
              coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
              srid: 27700
+           }
+  end
+
+  test "calculate_polygonz_bbox_with_srid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+
+    assert GeoMeasure.bbox(geom) == %Geo.Polygon{
+             coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]],
+             srid: 23700,
+             properties: %{min_z: 0, max_z: 2}
            }
   end
 
@@ -184,6 +256,11 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_centroid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]]}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}}
+  end
+
+  test "calculate_polygonz_centroid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}}
   end
 
   test "calculate_point_centroid_nil_coord" do
@@ -236,6 +313,11 @@ defmodule GeoMeasure.Test do
     assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
   end
 
+  test "calculate_polygonz_centroid_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.centroid(geom) end
+  end
+
   test "calculate_point_centroid_with_srid" do
     geom = %Geo.Point{coordinates: {1, 2}, srid: 23700}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1, 2}, srid: 23700}
@@ -282,6 +364,11 @@ defmodule GeoMeasure.Test do
   test "calculate_polygon_centroid_with_srid" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {2, 0}, {0, 0}]], srid: 23700}
     assert GeoMeasure.centroid(geom) == %Geo.Point{coordinates: {1.0, 1.0}, srid: 23700}
+  end
+
+  test "calculate_polygonz_centroid_with_srid" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]], srid: 23700}
+    assert GeoMeasure.centroid(geom) == %Geo.PointZ{coordinates: {1.0, 1.0, 1.0}, srid: 23700}
   end
 
   test "calculate_distance_x_direction" do
@@ -429,6 +516,11 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.extent(geom) == {0, 2, 0, 2}
   end
 
+  test "calculate_polygonz_extent" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.extent(geom) == {0, 2, 0, 2, 0, 2}
+  end
+
   test "calculate_linestring_extent_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, 2}, {nil, 4}]}
     assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
@@ -446,6 +538,11 @@ defmodule GeoMeasure.Test do
 
   test "calculate_polygon_extent_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {0, 2}, {2, 2}, {nil, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
+  end
+
+  test "calculate_polygonz_extent_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, nil, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.extent(geom) end
   end
 
@@ -500,6 +597,22 @@ defmodule GeoMeasure.Test do
     assert GeoMeasure.perimeter(geom) == 16.0
   end
 
+  test "calculate_polygonz_perimeter" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.perimeter(geom) == 8.94427190999916
+  end
+
+  test "calculate_polygonz_perimeter_hole" do
+    geom = %Geo.PolygonZ{
+      coordinates: [
+        [{0, 0, 0}, {0, 3, 1}, {3, 3, 2}, {3, 0, 1}, {0, 0, 0}],
+        [{1, 1, 0.66}, {1, 2, 1}, {2, 2, 1.33}, {2, 1, 1}, {1, 1, 0.66}]
+      ]
+    }
+
+    assert GeoMeasure.perimeter(geom) == 16.8676364068953
+  end
+
   test "calculate_linestring_length_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, nil}, {1, 4}]}
     assert_raise ArgumentError, fn -> GeoMeasure.length(geom) end
@@ -517,6 +630,11 @@ defmodule GeoMeasure.Test do
 
   test "calculate_polygon_perimeter_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.perimeter(geom) end
+  end
+
+  test "calculate_polygonz_perimeter_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.perimeter(geom) end
   end
 end

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -89,7 +89,10 @@ defmodule GeoMeasure.Perimeter.Test do
   end
 
   test "calculate_polygonz_perimeter_nil_coord" do
-    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]}
+    geom = %Geo.PolygonZ{
+      coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]
+    }
+
     assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 end

--- a/test/geomeasure/perimeter_test.exs
+++ b/test/geomeasure/perimeter_test.exs
@@ -52,6 +52,22 @@ defmodule GeoMeasure.Perimeter.Test do
     assert GeoMeasure.Perimeter.calculate(geom) == 16.0
   end
 
+  test "calculate_polygonz_perimeter" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {0, 2, 1}, {2, 2, 2}, {2, 0, 1}, {0, 0, 0}]]}
+    assert GeoMeasure.Perimeter.calculate(geom) == 8.94427190999916
+  end
+
+  test "calculate_polygonz_perimeter_hole" do
+    geom = %Geo.PolygonZ{
+      coordinates: [
+        [{0, 0, 0}, {0, 3, 1}, {3, 3, 2}, {3, 0, 1}, {0, 0, 0}],
+        [{1, 1, 0.66}, {1, 2, 1}, {2, 2, 1.33}, {2, 1, 1}, {1, 1, 0.66}]
+      ]
+    }
+
+    assert GeoMeasure.Perimeter.calculate(geom) == 16.8676364068953
+  end
+
   test "calculate_linestring_length_nil_coord" do
     geom = %Geo.LineString{coordinates: [{1, nil}, {1, 4}]}
     assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
@@ -69,6 +85,11 @@ defmodule GeoMeasure.Perimeter.Test do
 
   test "calculate_polygon_perimeter_nil_coord" do
     geom = %Geo.Polygon{coordinates: [[{0, 0}, {nil, 2}, {2, nil}, {2, 0}, {0, 0}]]}
+    assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
+  end
+
+  test "calculate_polygonz_perimeter_nil_coord" do
+    geom = %Geo.PolygonZ{coordinates: [[{0, 0, 0}, {nil, 2, 0}, {2, nil, 0}, {2, 0, 0}, {0, 0, 0}]]}
     assert_raise ArgumentError, fn -> GeoMeasure.Perimeter.calculate(geom) end
   end
 end


### PR DESCRIPTION
This PR aims to add support for all calculations involving LineStringZ, LineStringZM, and PolygonZ structs, with the exception of PolygonZ area.